### PR TITLE
Correct the service name in the Scanner and Ingress

### DIFF
--- a/server/templates/scanner-deployment.yaml
+++ b/server/templates/scanner-deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - "--password"
         - "{{ required "Please specify a password for a user associated with the Scanner role!" .Values.scanner.password }}"
         - "--host"
-        - "http://{{ .Release.Name }}-console:{{ .Values.web.service.externalPort }}"
+        - "http://{{ .Release.Name }}-console-svc:{{ .Values.web.service.externalPort }}"
         volumeMounts:
         - mountPath: /var/run/docker.sock
           name: docker-socket-mount

--- a/server/templates/web-ingress.yaml
+++ b/server/templates/web-ingress.yaml
@@ -23,7 +23,7 @@ spec:
           paths:
             - path: /
               backend:
-                serviceName: {{ $fullname }}-console
+                serviceName: {{ .Release.Name }}-console-svc
                 servicePort: {{ $servicePort }}
     {{- end -}}
   {{- if .Values.web.ingress.tls }}


### PR DESCRIPTION
The service name referenced in the Ingress definition did not match
the name in the actual web service. This commit corrects that.