### PR TITLE
Correct image pull secret name in service account

### DIFF
--- a/enforcer/templates/serviceaccount.yaml
+++ b/enforcer/templates/serviceaccount.yaml
@@ -9,4 +9,4 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 imagePullSecrets:
-- name: {{ .Values.imageCredentials.name }}
+- name: {{ .Release.Name }}-registry-secret

--- a/enforcer/values.yaml
+++ b/enforcer/values.yaml
@@ -1,6 +1,5 @@
 imageCredentials:
   create: false
-  imageCredentials.name:
   repositoryUriPrefix: "registry.aquasec.com" # for dockerhub - "docker.io"
   registry: "registry.aquasec.com" #REQUIRED only if create is true, for dockerhub - "index.docker.io/v1/"
   username: ""


### PR DESCRIPTION
The image pull secret reference in the service account definition
did not match the actual image pull secret. This commit changes the
reference to work like the corresponding reference in the server,
which works correctly.