### PR TITLE
Enforces the DB password secret, even if an external DB is used

### DIFF
--- a/server/templates/db-password-secret.yaml
+++ b/server/templates/db-password-secret.yaml
@@ -1,4 +1,21 @@
-{{- if not .Values.db.external.enabled }}
+{{- if .Values.db.external.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-database-password
+  labels:
+    app: {{ .Release.Name }}-database
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": before-hook-creation
+type: Opaque
+data:
+  db-password: {{ .Values.db.external.password }}
+{{- else }}
 ---
 apiVersion: v1
 kind: Secret

--- a/server/templates/db-password-secret.yaml
+++ b/server/templates/db-password-secret.yaml
@@ -14,7 +14,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 type: Opaque
 data:
-  db-password: {{ .Values.db.external.password }}
+  db-password: {{ .Values.db.external.password | b64enc | quote }}
 {{- else }}
 ---
 apiVersion: v1

--- a/server/templates/gate-deployment.yaml
+++ b/server/templates/gate-deployment.yaml
@@ -29,14 +29,10 @@ spec:
         - name: SCALOCK_DBUSER
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.user "postgres" }}
         - name: SCALOCK_DBPASSWORD
-          {{- if .Values.db.external.enabled }}
-          value: {{ .Values.db.external.password }}
-          {{- else }}
           valueFrom:
             secretKeyRef:
               name: {{ .Release.Name }}-database-password
               key: db-password
-          {{- end }}
         - name: SCALOCK_DBNAME
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.name "scalock" }}
         - name: SCALOCK_DBHOST
@@ -50,14 +46,10 @@ spec:
         - name: SCALOCK_AUDIT_DBUSER
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.auditUser "postgres" }}
         - name: SCALOCK_AUDIT_DBPASSWORD
-          {{- if .Values.db.external.enabled }}
-          value: {{ .Values.db.external.auditPassword }}
-          {{- else }}
           valueFrom:
             secretKeyRef:
               name: {{ .Release.Name }}-database-password
               key: db-password
-          {{- end }}
         - name: SCALOCK_AUDIT_DBNAME
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.auditName "slk_audit" }}
         - name: SCALOCK_AUDIT_DBHOST

--- a/server/templates/web-deployment.yaml
+++ b/server/templates/web-deployment.yaml
@@ -25,14 +25,10 @@ spec:
         - name: SCALOCK_DBUSER
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.user "postgres" }}
         - name: SCALOCK_DBPASSWORD
-          {{- if .Values.db.external.enabled }}
-          value: {{ .Values.db.external.password }}
-          {{- else }}
           valueFrom:
             secretKeyRef:
               name: {{ .Release.Name }}-database-password
               key: db-password
-          {{- end }}
         - name: SCALOCK_DBNAME
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.name "scalock" }}
         - name: SCALOCK_DBHOST
@@ -46,14 +42,10 @@ spec:
         - name: SCALOCK_AUDIT_DBUSER
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.auditUser "postgres" }}
         - name: SCALOCK_AUDIT_DBPASSWORD
-          {{- if .Values.db.external.enabled }}
-          value: {{ .Values.db.external.auditPassword }}
-          {{- else }}
           valueFrom:
             secretKeyRef:
               name: {{ .Release.Name }}-database-password
               key: db-password
-          {{- end }}
         - name: SCALOCK_AUDIT_DBNAME
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.auditName "slk_audit" }}
         - name: SCALOCK_AUDIT_DBHOST


### PR DESCRIPTION
Currently if an external DB is used the password is set via environment variables without using secrets.  I believe it is better to populate the secret with the value anyway and use that in the deployment.