### PR TITLE
Make the admin password and license tokens secrets for the web console

### DIFF
--- a/server/templates/web-deployment.yaml
+++ b/server/templates/web-deployment.yaml
@@ -66,11 +66,17 @@ spec:
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.auditPort "5432" | quote }}
           {{- if .Values.admin.token }}
         - name: LICENSE_TOKEN
-          value: {{ .Values.admin.token }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-console-secrets
+              key: license-token
           {{- end }}
           {{- if .Values.admin.password }}
         - name: ADMIN_PASSWORD
-          value: {{ .Values.admin.password }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-console-secrets
+              key: admin-password
           {{- end }}
         ports:
         - containerPort: 8080

--- a/server/templates/web-secrets.yaml
+++ b/server/templates/web-secrets.yaml
@@ -1,0 +1,22 @@
+{{- if or (( .Values.admin.password) .Values.admin.token) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-console-secrets
+  labels:
+    app: {{ .Release.Name }}-console
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+metadata:
+  name: {{ .Release.Name }}-console-secrets
+type: Opaque
+data:
+{{- if .Values.admin.password }}
+  admin-password: {{ .Values.admin.password | b64enc | quote }}
+{{- end }}
+{{- if .Values.admin.token }}
+  license-token: {{ .Values.admin.token | b64enc | quote }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Currently the admin password and license keys are available in plain environment variables, this PR fixes this.