### PR TITLE
Add toleration support

### DIFF
--- a/enforcer/templates/enforcer-daemonset.yaml
+++ b/enforcer/templates/enforcer-daemonset.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         app: {{ .Release.Name }}-ds
       name: {{ .Release.Name }}-ds
+      annotations:
+      {{- if and (.Values.tolerations) (semverCompare "<1.6-0" .Capabilities.KubeVersion.GitVersion) }}
+        scheduler.alpha.kubernetes.io/tolerations: '{{ toJson .Values.tolerations }}'
+      {{- end }}
     spec:
       serviceAccount: {{ .Release.Name }}-sa
       hostPID: true
@@ -90,4 +94,8 @@ spec:
       {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if and (.Values.tolerations) (semverCompare "^1.6-0" .Capabilities.KubeVersion.GitVersion) }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
       {{- end }}

--- a/enforcer/values.yaml
+++ b/enforcer/values.yaml
@@ -33,3 +33,9 @@ resources:
   limits:
     memory: "300Mi"
     cpu: "60m"
+
+tolerations: []
+# - key: "key"
+#   operator: "Equal|Exists"
+#   value: "value"
+#   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"


### PR DESCRIPTION
This adds support for setting tolerations on the enforcer
daemonset. This allows you to run an enforcer on a tainted node,
for example the master node is usually tainted.