### PR TITLE
Fix the service name in the server ingess

### DIFF
--- a/server/templates/web-ingress.yaml
+++ b/server/templates/web-ingress.yaml
@@ -23,7 +23,7 @@ spec:
           paths:
             - path: /
               backend:
-                serviceName: {{ .Release.Name }}-console-svc
+                serviceName: {{ $fullname }}-console-svc
                 servicePort: {{ $servicePort }}
     {{- end -}}
   {{- if .Values.web.ingress.tls }}


### PR DESCRIPTION
The previous reference didn't resolve in the context. This change
makes it use the `$fullname` from the `range` context.