### PR TITLE
Error can't evaluate field nodeSelector in type interface {} when specifying a nodeSelector

### DIFF
--- a/enforcer/templates/enforcer-daemonset.yaml
+++ b/enforcer/templates/enforcer-daemonset.yaml
@@ -124,7 +124,7 @@ spec:
       - name: aquasec-audit
         hostPath:
           path: /var/lib/aquasec/audit
-      {{- with .Values.nodeSelector }}
+      {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       {{- end }}


### PR DESCRIPTION
### Full error:

```
Error: render error in "enforcer/templates/enforcer-daemonset.yaml":
template: enforcer/templates/enforcer-daemonset.yaml:129:17: executing
"enforcer/templates/enforcer-daemonset.yaml" at <.Values.nodeSelector>: can't evaluate
field nodeSelector in type interface {}
```

Traced this down to needing to modify the enforcer-daemonset.yaml template to change `with .Values.nodeSelector` to `if .Values.nodeSelector`.

---

### Before change:

```shell
$ helm --debug install . --set-string nodeSelector.enforcer=true,image.tag=4.0.19113

[debug] Created tunnel using local port: '52049'

[debug] SERVER: "127.0.0.1:52049"

[debug] Original chart version: ""
[debug] CHART PATH: /Users/yungjames/CODE/github/jamsyoung/aqua-helm/enforcer

Error: render error in "enforcer/templates/enforcer-daemonset.yaml": template:
enforcer/templates/enforcer-daemonset.yaml:129:17: executing
"enforcer/templates/enforcer-daemonset.yaml" at <.Values.nodeSelector>: can't evaluate
field nodeSelector in type interface {}
```

### After changing:

There is no error. It works as expected.