### PR TITLE
made use of hosts in console web ingress optional

### DIFF
--- a/server/templates/web-ingress.yaml
+++ b/server/templates/web-ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{ toYaml .Values.web.ingress.annotations | indent 4 }}
 {{- end }}
 spec:
+  {{ if .Values.web.ingress.hosts }}
   rules:
     {{- range $host := (required "A valid .Values.web.ingress.hosts entry required!" .Values.web.ingress.hosts) }}
       - host: {{ $host }}
@@ -26,6 +27,11 @@ spec:
                 serviceName: {{ $fullname }}-console-svc
                 servicePort: {{ $servicePort }}
     {{- end -}}
+  {{ else }}
+  backend:
+    serviceName: {{ $fullname }}-console-svc
+    servicePort: {{ $servicePort }}
+  {{ end }}
   {{- if .Values.web.ingress.tls }}
   tls:
 {{ toYaml .Values.web.ingress.tls | indent 4 }}


### PR DESCRIPTION
I was running into issues on GKE with the default ingress where the host wasn't being passed to the ingress load balancer, and the request was being proxied to the default backend:

$ curl -H "Host: aqua.poshdevelopment.com" https://{mydomain}/js/8e57a6b0.js                                                                             
default backend - 404

This was causing the main page, https://{mydomain}/ to load as a blank page,
since none of the javascript could load.

I altered the helm deployment so that you don't have to provide a host, and
if you don't, it just uses the CSP service as the only backend.