### PR TITLE
Add resource key for enforce, use resources and probe keys

### DIFF
--- a/enforcer/templates/enforcer-daemonset.yaml
+++ b/enforcer/templates/enforcer-daemonset.yaml
@@ -102,6 +102,16 @@ spec:
           name: aquasec-tmp
         - mountPath: /opt/aquasec/audit
           name: aquasec-audit
+{{- with .Values.livenessProbe }}
+        livenessProbe:
+{{ toYaml . | indent 10 }}
+{{- end }}
+{{- with .Values.readinessProbe }}
+        readinessProbe:
+{{ toYaml . | indent 10 }}
+{{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 12 }}
       volumes:
       - name: var-run
         hostPath:

--- a/enforcer/values.yaml
+++ b/enforcer/values.yaml
@@ -33,5 +33,12 @@ image:
 
 livenessProbe: {}
 readinessProbe: {}
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
Allows users to set enforcer resources, and also included updates to allow the enforcer deployment to use already present readiness/liveness probes (which appears to have no application currently in the enforcer daemonset file)