### PR TITLE
Remove the reference to the namespace in the rbac template file #54

### DIFF
--- a/enforcer/templates/rbac.yaml
+++ b/enforcer/templates/rbac.yaml
@@ -54,7 +54,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-role-binding
-  namespace: aqua
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -63,7 +63,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-sa
-    namespace: aqua
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Dynamically adds namespace in rbac template file as per comments in aquasecurity/aqua-helm#54.