### PR TITLE
Addin in annotations to services and changed fixed namespace

### DIFF
--- a/enforcer/templates/rbac.yaml
+++ b/enforcer/templates/rbac.yaml
@@ -54,7 +54,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-role-binding
-  namespace: aqua
+  namespace: {{.Release.namespace}}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -63,7 +63,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-sa
-    namespace: aqua
+    namespace: {{.Release.namespace}}
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io

--- a/enforcer/templates/rbac.yaml
+++ b/enforcer/templates/rbac.yaml
@@ -54,7 +54,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-role-binding
-  namespace: {{.Release.namespace}}
+  namespace: {{ .Release.namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -63,7 +63,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-sa
-    namespace: {{.Release.namespace}}
+    namespace: {{ .Release.namespace }}
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io

--- a/enforcer/templates/rbac.yaml
+++ b/enforcer/templates/rbac.yaml
@@ -54,7 +54,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-role-binding
-  namespace: {{ .Release.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -63,7 +63,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-sa
-    namespace: {{ .Release.namespace }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io

--- a/server/templates/db-service.yaml
+++ b/server/templates/db-service.yaml
@@ -4,6 +4,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-database-svc
+  {{- with .Values.db.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
   labels:
     app: {{ .Release.Name }}-database
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/gate-service.yaml
+++ b/server/templates/gate-service.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-gateway-svc
+  {{- with .Values.gate.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
   labels:
     app: {{ .Release.Name }}-gateway
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/rbac.yaml
+++ b/server/templates/rbac.yaml
@@ -53,7 +53,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-role-binding
-  namespace: {{.Release.namespace}}
+  namespace: {{ .Release.namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -62,7 +62,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-sa
-    namespace: {{.Release.namespace}}
+    namespace: {{ .Release.namespace }}
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io

--- a/server/templates/rbac.yaml
+++ b/server/templates/rbac.yaml
@@ -53,7 +53,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-role-binding
-  namespace: aqua
+  namespace: {{.Release.namespace}}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -62,7 +62,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-sa
-    namespace: aqua
+    namespace: {{.Release.namespace}}
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io

--- a/server/templates/rbac.yaml
+++ b/server/templates/rbac.yaml
@@ -53,7 +53,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-role-binding
-  namespace: {{ .Release.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -62,7 +62,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-sa
-    namespace: {{ .Release.namespace }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io

--- a/server/templates/web-service.yaml
+++ b/server/templates/web-service.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-console-svc
+  {{- with .Values.web.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
   labels:
     app: {{ .Release.Name }}-console
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -53,6 +53,7 @@ db:
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP
+    annotations: {}
   persistence:
     enabled: true
     storageClass:
@@ -95,6 +96,7 @@ gate:
   service:
     type: ClusterIP
     externalPort: 3622
+    annnotations: {}
   publicIP: aqua-gateway
   replicaCount: 1
   livenessProbe: {}
@@ -118,6 +120,7 @@ web:
   service:
     type: ClusterIP
     externalPort: 8080
+    annnotations: {}
   encryptionKey:
   ingress:
     enabled: false


### PR DESCRIPTION
Updated the helm charts to include annotations on the services. This is required for environments like Azure when you need to specify internal load balancers / subnets etc.

Also, the rbac.yaml files contained hard coded references to the Aqua namespace. These will now be picked up from the helm deployment.