### PR TITLE
Remove default namespace

### DIFF
--- a/enforcer/templates/rbac.yaml
+++ b/enforcer/templates/rbac.yaml
@@ -54,7 +54,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-role-binding
-  namespace: aqua
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -63,7 +62,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-sa
-    namespace: aqua
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io

--- a/examples/ingress-example.yaml
+++ b/examples/ingress-example.yaml
@@ -5,7 +5,6 @@ metadata:
     ingress.kubernetes.io/rewrite-target: /
     ingress.kubernetes.io/add-base-url: "true"
   name: aqua-console
-  namespace: aqua
 spec:
   rules:
   - http:

--- a/server/templates/rbac.yaml
+++ b/server/templates/rbac.yaml
@@ -53,7 +53,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-role-binding
-  namespace: aqua
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -62,7 +61,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-sa
-    namespace: aqua
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Signed-off-by: Julien Garcia Gonzalez <julien@giantswarm.io>

The current version on helm charts includes namespace in RBAC resources, which break if you specify other namespace than `aqua` during installation.