### PR TITLE
Fix 'serviceName' parameter of scanner in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Change some or all of these parameters per the requirements of your deployment, 
 | `admin.password`                    | Use this Aqua admin password   | `N/A`                                                                  |
 | `docker.socket.path`                    | Docker Socket Path   | `/var/run/docker.sock`                                                                  |
 | `serviceAccount`                    | Service account to use   | `csp-sa`                                                                  |
-| `server.serviceName`                    | Service name of the Aqua Server (console) UI   | `csp-consul-svc`                                                                  |
+| `server.serviceName`                    | Service name of the Aqua Server (console) UI   | `csp-console-svc`                                                                  |
 | `server.port`                    | Service svc port   | `8080`                                                                  |
 | `docker.socket.path`                    | Docker socket path   | `/var/run/docker.sock`                                                                  |
 | `docker.socket.path`                    | Docker socket path   | `/var/run/docker.sock`                                                                  |


### PR DESCRIPTION
Previously it was 'consul', I was confused about it. I thought it looks for a consul to connect. Checked in helm chart and it was 'console'. I guess it is a simple typo.