### PR TITLE
Bugfix: Use release namespace for ClusterRoleBinding

### DIFF
--- a/server/templates/rbac.yaml
+++ b/server/templates/rbac.yaml
@@ -53,7 +53,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-role-binding
-  namespace: aqua
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -62,7 +62,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-sa
-    namespace: aqua
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
The ClusterRoleBinding's namespace and subject's namespace were hardcoded to "aqua",
which would cause the ClusterRoleBinding not to be applied to the service account if
the namespace for the install was not "aqua".