### PR TITLE
Adding the ability to add annotations to gate-service for AWS ALB spe…

### DIFF
--- a/server/templates/gate-service.yaml
+++ b/server/templates/gate-service.yaml
@@ -9,6 +9,8 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+{{ toYaml .Values.gate.service.annotations | indent 4}}
 spec:
   type: {{ .Values.gate.service.type }}
   selector:


### PR DESCRIPTION
AWS ALB and other services require specific configurations by annotations.

Example:

```
  grpcservice:
    annotations:
      external-dns.alpha.kubernetes.io/hostname: aqua-gateway.company.domain
      service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
```