### PR TITLE
Improvemnts for KubeEnforcer helm charts (clone to 5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,9 +203,7 @@ Change some or all of these parameters per the requirements of your deployment, 
 | `imageCredentials.create`               | Set if to create new pull image secret    | `true`                                                                 |
 | `imageCredentials.name`               | Your Docker pull image secret name    | `aqua-image-pull-secret`                                                                   |
 | `imageCredentials.username`               | Your Docker registry (DockerHub, etc.) username    | `N/A`                                                                   |
-| `imageCredentials.password`               | Your Docker registry (DockerHub, etc.) password    | `N/A`                                                                   |
-| `aquaSecret.aquaUsername`                           | Aqua Console Username    | `N/A`
-| `aquaSecret.aquaPassword`                           | Aqua Console Password   | `N/A`
+| `imageCredentials.password`               | Your Docker registry (DockerHub, etc.) password    | `N/A`
 | `aquaSecret.kubeEnforcerToken`                           | Aqua KubeEnforcer token    | `N/A`    
 | `certsSecret.serverCertificate`                           | Certificate for TLS authentication with Kubernetes api-server    | `N/A`
 | `certsSecret.serverKey`                           | Certificate key for TLS authentication with Kubernetes api-server    | `N/A`
@@ -258,7 +256,7 @@ helm upgrade --install --namespace aqua csp-enforcer ./enforcer --set imageCrede
 ### KubeEnforcer chart
 
 ```bash
-helm upgrade --install --namespace aqua kube-enforcer ./kube-enforcer --set imageCredentials.username=<registry-username>,imageCredentials.password=<registry-password>,aquaSecret.kubeEnforcerToken=<kube-enforcer-token>,certsSecret.serverCertificate="$(cat server.crt)",certsSecret.serverKey="$(cat server.key)",validatingWebhook.caBundle="$(cat ca.crt)",aquaSecret.aquaUsername=<aqua-username>,aquaSecret.aquaPassword=<aqua-password>
+helm upgrade --install --namespace aqua kube-enforcer ./kube-enforcer --set imageCredentials.username=<registry-username>,imageCredentials.password=<registry-password>,certsSecret.serverCertificate="$(cat server.crt)",certsSecret.serverKey="$(cat server.key)",validatingWebhook.caBundle="$(cat ca.crt)"
 ```
 
 ### Scanner chart (optional)

--- a/kube-enforcer/README.md
+++ b/kube-enforcer/README.md
@@ -7,7 +7,7 @@ Contents:
     - [Installing the Chart](#installing-the-chart)
   - [Issues and feedback](#issues-and-feedback)
 
-## Configure TLS Authentication to the API Server
+## Configure TLS Authentication between KubeEnforcer & API Server
 
 You need to enable TLS authentication from the API Server to the Kube-Enforcer. Perform these steps:
 
@@ -33,6 +33,8 @@ openssl req -new -key server.key -out server.csr -subj "/CN=aqua-kube-enforcer.a
 openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 100000 -extensions v3_req -extfile server.conf
 ```
 
+You also also use your own certificates without generating new ones for TLS authentication all we need is root CA certificate, certificate signed by CA and certificate key.
+
 ## Deploy The Helm Chart
 
 **(Optional)** create the secret:
@@ -54,7 +56,14 @@ git clone https://github.com/aquasecurity/kube-enforcer-helm.git
 ***Optional*** Update the Helm charts values.yaml file with your environment's custom values, registry secret, aqua console credentials & TLS certificates. This eliminates the need to pass the parameters to the helm command. Then run one of the commands below to install the relevant services.
 
 ```bash
-helm install <release_name> kube-enforcer --set imageCredentials.username=<registry-username>,imageCredentials.password=<registry-password>,aquaSecret.kubeEnforcerToken=<kube-enforcer-token>,certsSecret.serverCertificate="$(cat server.crt)",certsSecret.serverKey="$(cat server.key)",validatingWebhook.caBundle="$(cat ca.crt)",aquaSecret.aquaUsername=<aqua-username>,aquaSecret.aquaPassword=<aqua-password>
+helm install <release_name> kube-enforcer --set imageCredentials.username=<registry-username>,imageCredentials.password=<registry-password>,certsSecret.serverCertificate="$(cat server.crt)",certsSecret.serverKey="$(cat server.key)",validatingWebhook.caBundle="$(cat ca.crt)"
+```
+
+Optional flags:
+
+```
+--namespace                              default to aqua
+--aquaSecret.kubeEnforcerToken           default to "" you can find the KubeEnforcer token from aqua csp under enforcers tab in default/custom KubeEnforcer group or you can manually approve KubeEnforcer authentication from aqua CSP under default/custom KubeEnforcer group in enforcers tab. 
 ```
 
 ## Issues and feedback

--- a/kube-enforcer/templates/_helpers.tpl
+++ b/kube-enforcer/templates/_helpers.tpl
@@ -46,15 +46,3 @@ Create chart name and version as used by the chart label.
 {{- define "caBundle" }}
 {{- printf "%s" (required "A valid .Values.validatingWebhook.caBundle entry required!" .Values.validatingWebhook.caBundle) | b64enc | replace "\n" "" }}
 {{- end }}
-
-{{- define "token" }}
-{{- printf "%s" (required "A valid .Values.aquaSecret.kubeEnforcerToken entry required!" .Values.aquaSecret.kubeEnforcerToken) | b64enc }}
-{{- end }}
-
-{{- define "username" }}
-{{- printf "%s" (required "A valid .Values.aquaSecret.aquaUsername entry required!" .Values.aquaSecret.aquaUsername) | b64enc }}
-{{- end }}
-
-{{- define "password" }}
-{{- printf "%s" (required "A valid .Values.aquaSecret.aquaPassword entry required!" .Values.aquaSecret.aquaPassword) | b64enc }}
-{{- end }}

--- a/kube-enforcer/templates/kube-enforcer-deployment.yaml
+++ b/kube-enforcer/templates/kube-enforcer-deployment.yaml
@@ -19,18 +19,8 @@ spec:
           image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: Always
           ports:
-            - containerPort: 8080
+            - containerPort: 8443
           env:
-            - name: USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.aquaSecret.name }}
-                  key: username
-            - name: PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.aquaSecret.name }}
-                  key: password
             - name: AQUA_TOKEN
               valueFrom: 
                 secretKeyRef:

--- a/kube-enforcer/templates/kube-enforcer-token.yaml
+++ b/kube-enforcer/templates/kube-enforcer-token.yaml
@@ -5,6 +5,4 @@ metadata:
   namespace: {{ .Values.namespace }}
 type: Opaque
 data:
-  username: {{ template "username" . }}            # place server username
-  password: {{ template "password" . }}            # place server password
-  token:    {{ template "token" . }}               # aqua kube enforcer token
+  token:    {{ .Values.aquaSecret.kubeEnforcerToken | b64enc | quote }}               # aqua kube enforcer token

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -2,7 +2,7 @@
 imageCredentials:
   # If aqua-registry already exists in the cluster. Make create to false. So it won't attempt to create a new registry secret. 
   create: true
-  name: aqua-image-pull-secret # example
+  name: csp-registry-secret # example
   repositoryUriPrefix: "registry.aquasec.com" # for dockerhub - "docker.io"
   registry: "registry.aquasec.com" #REQUIRED only if create is true, for dockerhub - "index.docker.io/v1/"
   username: ""
@@ -17,7 +17,7 @@ aqua_cache_expiration_period: 60
 
 image:
   repository: kube-enforcer
-  tag: 5.0
+  tag: "5.0"
   pullPolicy: Always
 
 nameOverride: "aqua-kube-enforcer"
@@ -27,17 +27,15 @@ namespace: "aqua"
 
 certsSecret:
   name: aqua-kube-enforcer-certs
-  serverCertificate: "fgfdgfdgfdgfdgsdrgfdfd"
+  serverCertificate: ""
   serverKey: ""
 
 aquaSecret:
-  name: aqua-kube-enforcer-token  
-  aquaUsername: ""
-  aquaPassword: ""
+  name: aqua-kube-enforcer-token
   kubeEnforcerToken: ""
 
 envs:
-  gatewayAddress: aqua-gateway:8443 
+  gatewayAddress: csp-gateway-svc:8443 
 
 
 serviceAccount:
@@ -52,11 +50,3 @@ clusterRoleBinding:
 validatingWebhook:
   name: kube-enforcer-admission-hook-config
   caBundle: ""
-
-resources: {}
-  # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
-  # requests:
-  #  cpu: 100m
-  #  memory: 128Mi


### PR DESCRIPTION
We dropped using aqua csp username & password in KubeEnforcer deployment & also made improvements suggest by Andreas.

@eranbibi @niso120b 