### PR TITLE
fix spelling, capitalization, and formatting errors in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ $ helm search repo aqua-helm
 Example output:
 
 ```csv
-NAME                      CHART VERSION		    APP VERSION		      DESCRIPTION
-aqua-helm/enforcer        5.0.0        			  5.0        				  A Helm chart for the Aqua Enforcer
-aqua-helm/scanner 	      5.0.0        			  5.0        				  A Helm chart for the aqua scanner cli component
-aqua-helm/server  	      5.0.0        			  5.0        				  A Helm chart for the Aqua Console Componants
-aqua-helm/kube-enforcer   5.0.0                   5.0                         A helm chart for the Aqua KubeEnforcer
+NAME                      CHART VERSION       APP VERSION         DESCRIPTION
+aqua-helm/enforcer        5.0.0               5.0                 A Helm chart for the Aqua Enforcer
+aqua-helm/scanner         5.0.0               5.0                 A Helm chart for the Aqua Scanner CLI component
+aqua-helm/server          5.0.0               5.0                 A Helm chart for the Aqua Console components
+aqua-helm/kube-enforcer   5.0.0               5.0                 A Helm chart for the Aqua KubeEnforcer
 ```
 
 * Search for all components of a specific version in our Aqua Helm repository

--- a/kube-enforcer/Chart.yaml
+++ b/kube-enforcer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.0"
-description: A Helm chart for Aqua KubeEnforcer
+description: A Helm chart for the Aqua KubeEnforcer
 name: kube-enforcer
 version: 0.1.0
 icon: https://avatars3.githubusercontent.com/u/12783832?s=200&v=4

--- a/scanner/Chart.yaml
+++ b/scanner/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 appVersion: "5.0"
-description: A Helm chart for the aqua scanner cli component
+description: A Helm chart for the Aqua Scanner CLI component
 name: scanner
 version: 5.0.0

--- a/server/Chart.yaml
+++ b/server/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 appVersion: "5.0"
-description: A Helm chart for the Aqua Console Componants
+description: A Helm chart for the Aqua Console components
 name: server
 version: 5.0.0


### PR DESCRIPTION
## Description

- README list of Charts mixed spaces and tabs which caused it to display
  unevenly and be harder to read
  - use spaces consistently instead

- spelling: "Componants" -> "components"

- capitalization and standardization:
  - use "components" or "component" lowercase consistently
  - capitalize "Scanner" and "CLI" consistently
    - previously were lowercase or uppercase in different places
  - use "chart for the Aqua ..." instad of "chart for Aqua ..."
    consistently
    - most places used "the" already, so just use that consistently

## Visual Diff

Formatting in README "output" table:

**Before**:
![Screen Shot 2020-07-15 at 3 46 20 PM](https://user-images.githubusercontent.com/4970083/87588977-8a994400-c6b2-11ea-88ab-90028561fd17.png)

**After**:
![Screen Shot 2020-07-15 at 3 46 57 PM](https://user-images.githubusercontent.com/4970083/87588996-91c05200-c6b2-11ea-9147-ba34eb9d8c5c.png)

## Tags

Related to #57 