### PR TITLE
feat: add Tenant Manager Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ CSP deployments include the following components:
 - Enforcer
 - KubeEnforcer
 - Scanner
+- Tenant Manager
 
 ## Contents
 
@@ -30,6 +31,7 @@ This repository includes three charts that may be deployed separately:
 * [**Enforcer**](enforcer/) - deploys the Enforcer daemonset
 * [**Scanner**](scanner/) - deploys the Scanner deployment
 * [**KubeEnforcer**](kube-enforcer/) - deploys the KubeEnforcer deployment
+* [**TenantManager**](tenant-manager/) - deploys the Tenant Manager deployment
 
 # Deployment instructions
 
@@ -64,6 +66,7 @@ NAME                      CHART VERSION		    APP VERSION		      DESCRIPTION
 aqua-helm/enforcer        5.0.0        			  5.0        				  A Helm chart for the Aqua Enforcer
 aqua-helm/scanner 	      5.0.0        			  5.0        				  A Helm chart for the aqua scanner cli component
 aqua-helm/server  	      5.0.0        			  5.0        				  A Helm chart for the Aqua Console Componants
+aqua-helm/tenant-manager  5.0.0               5.0                 A Helm chart for the Aqua Tenant Manager
 aqua-helm/kube-enforcer   5.0.0                   5.0                         A helm chart for the Aqua KubeEnforcer
 ```
 
@@ -147,6 +150,12 @@ helm upgrade --install --namespace aqua kube-enforcer ./kube-enforcer --set imag
 
 ```bash
 helm upgrade --install --namespace aqua scanner ./scanner --set imageCredentials.username=<>,imageCredentials.password=<>,imageCredentials.email=<>
+```
+
+## Tenant Manager chart (optional)
+
+```bash
+helm upgrade --install --namespace aqua aqua-tenant-manager ./tenant-manager --set imageCredentials.username=<>,imageCredentials.password=<>
 ```
 
 # Troubleshooting

--- a/tenant-manager/.helmignore
+++ b/tenant-manager/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/tenant-manager/Chart.yaml
+++ b/tenant-manager/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "5.0"
+description: A Helm chart for the Aqua Tenant Manager
+name: tenant-manager
+version: 5.0.0

--- a/tenant-manager/LICENSE
+++ b/tenant-manager/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tenant-manager/README.md
+++ b/tenant-manager/README.md
@@ -1,0 +1,64 @@
+<img src="https://avatars3.githubusercontent.com/u/12783832?s=200&v=4" height="100" width="100" /><img src="https://avatars3.githubusercontent.com/u/15859888?s=200&v=4" width="100" height="100"/>
+
+# Aqua Security Tenant Manager Helm Chart
+
+These are Helm charts for installation and maintenance of Aqua Container Security Platform Tenant Manager.
+
+## Contents
+
+- [Aqua Security Enforcer Tenant Manager Chart](#aqua-security-tenant-manager-helm-chart)
+  - [Contents](#contents)
+  - [Prerequisites](#prerequisites)
+    - [Container Registry Credentials](#container-registry-credentials)
+  - [Installing the Charts](#installing-the-charts)
+  - [Configurable Variables](#configurable-variables)
+    - [Tenant Manager](#tenant-manager)
+  - [Issues and feedback](#issues-and-feedback)
+  - [Support](#support)
+
+## Prerequisites
+
+### Container Registry Credentials
+
+[Link](../docs/imagepullsecret.md)
+
+## Installing the Charts
+
+Clone the GitHub repository with the charts
+
+```bash
+git clone https://github.com/aquasecurity/aqua-helm.git
+cd aqua-helm/
+```
+
+```bash
+helm upgrade --install --namespace aqua aqua-tenant-manager ./tenant-manager --set imageCredentials.username=<>,imageCredentials.password=<>
+```
+
+## Configurable Variables
+
+### Tenant Manager
+
+Parameter | Description | Default
+--------- | ----------- | -------
+`imageCredentials.create` | Set if to create new pull image secret | `false`
+`imageCredentials.name` | Your Docker pull image secret name | `aqua-registry-secret`
+`imageCredentials.repositoryUriPrefix` | repository uri prefix for dockerhub set `docker.io` | `registry.aquasec.com`
+`imageCredentials.registry` | set the registry url for dockerhub set `index.docker.io/v1/` | `registry.aquasec.com`
+`imageCredentials.username` | Your Docker registry (DockerHub, etc.) username | `aqua-registry-secret`
+`imageCredentials.password` | Your Docker registry (DockerHub, etc.) password | `unset`
+`image.repository` | the docker image name to use | `enforcer`
+`image.tag` | The image tag to use. | `5.0`
+`image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`
+`resources` |	Resource requests and limits | `{}`
+`nodeSelector` |	Kubernetes node selector	| `{}`
+`tolerations` |	Kubernetes node tolerations	| `[]`
+`affinity` |	Kubernetes node affinity | `{}`
+
+## Issues and feedback
+
+If you encounter any problems or would like to give us feedback on deployments, we encourage you to raise issues here on GitHub.
+
+## Support
+
+If you encounter any problems or would like to give us feedback on deployments, we encourage you to raise issues here on GitHub please contact us at https://github.com/aquasecurity.

--- a/tenant-manager/templates/NOTES.txt
+++ b/tenant-manager/templates/NOTES.txt
@@ -1,0 +1,9 @@
+
+Thank you for installing Aqua Tenant Manager.
+
+Now that you have deployed Aqua Tenant Manager, you should look over the docs on using:
+
+https://docs.aquasec.com/docs
+
+
+Your release is named {{ .Release.Name }}.

--- a/tenant-manager/templates/_helpers.tpl
+++ b/tenant-manager/templates/_helpers.tpl
@@ -1,0 +1,20 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "imagePullSecret" }}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" (required "A valid .Values.imageCredentials.registry entry required!" .Values.imageCredentials.registry) (printf "%s:%s" (required "A valid .Values.imageCredentials.username entry required!" .Values.imageCredentials.username) (required "A valid .Values.imageCredentials.password entry required!" .Values.imageCredentials.password) | b64enc) | b64enc }}
+{{- end }}

--- a/tenant-manager/templates/deployment.yaml
+++ b/tenant-manager/templates/deployment.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-tenant-manager
+  labels:
+    app: {{ .Release.Name }}-tenant-manager
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  template:
+    metadata:
+      annotations:
+      {{- if and (.Values.tolerations) (semverCompare "<1.6-0" .Capabilities.KubeVersion.GitVersion) }}
+        scheduler.alpha.kubernetes.io/tolerations: '{{ toJson .Values.tolerations }}'
+      {{- end }}
+      labels:
+        app: {{ .Release.Name }}-tenant-manager
+      name: {{ .Release.Name }}-tenant-manager
+    spec:
+      serviceAccount: {{ .Release.Name }}-sa
+      containers:
+      - name: tenant-manager
+        image: "{{ .Values.repositoryUriPrefix }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        env:
+          - name: AQUA_TM_DBNAME
+            value: "tenantmanager"
+          - name: AQUA_TM_DBUSER
+            value: "postgres"
+          - name: AQUA_TM_DBPASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: aqua-db
+                key: password
+          - name: AQUA_TM_DBHOST
+            value: aqua-db
+          - name: AQUA_TM_DBPORT
+            value: "5432"
+          - name: AQUA_TM_AUDIT_DBNAME
+            value: "tm_audit"
+          - name: AQUA_TM_AUDIT_DBUSER
+            value: "postgres"
+          - name: AQUA_TM_AUDIT_DBPASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: aqua-db
+                key: password
+          - name: AQUA_TM_AUDIT_DBHOST
+            value: aqua-db
+          - name: AQUA_TM_AUDIT_DBPORT
+            value: "5432"
+          - name: SCALOCK_LOG_LEVEL
+            value: "DEBUG"
+        ports:
+        - containerPort: 8081
+          protocol: TCP
+{{- with .Values.livenessProbe }}
+        livenessProbe:
+{{ toYaml . | indent 10 }}
+{{- end }}
+{{- with .Values.readinessProbe }}
+        readinessProbe:
+{{ toYaml . | indent 10 }}
+{{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- if and (.Values.tolerations) (semverCompare "^1.6-0" .Capabilities.KubeVersion.GitVersion) }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+      {{- end }}

--- a/tenant-manager/templates/image-pull-secret.yaml
+++ b/tenant-manager/templates/image-pull-secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.imageCredentials.create -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-registry-secret
+  labels:
+    app: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "imagePullSecret" . }}
+{{- end -}}

--- a/tenant-manager/templates/service.yaml
+++ b/tenant-manager/templates/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-tenant-manager-svc
+  labels:
+    app: {{ .Release.Name }}-tenant-manager
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  ports:
+    - port: 8081
+  selector:
+    app: {{ .Release.Name }}-tenant-manager

--- a/tenant-manager/templates/serviceaccount.yaml
+++ b/tenant-manager/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-sa
+  labels:
+    app: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+imagePullSecrets:
+{{- if .Values.imageCredentials.create }}
+- name: {{ .Release.Name }}-registry-secret
+{{- else }}
+- name: {{ .Values.imageCredentials.name }}
+{{- end }}

--- a/tenant-manager/values.yaml
+++ b/tenant-manager/values.yaml
@@ -1,0 +1,25 @@
+imageCredentials:
+  create: false
+  name: aqua-registry-secret # When create is false please specify
+  repositoryUriPrefix: "registry.aquasec.com" # for dockerhub - "docker.io"
+  registry: "registry.aquasec.com" #REQUIRED only if create is true, for dockerhub - "index.docker.io/v1/"
+  username: ""
+  password: ""
+
+image:
+  repository: tenant-manager
+  tag: "5.0"
+  pullPolicy: IfNotPresent
+
+livenessProbe: {}
+readinessProbe: {}
+resources: {}
+  # Note: For recommendations please check the official sizing guide.
+  # limits:
+  #   cpu: 800m
+  #   memory: 2G
+  # requests:
+  #   cpu: 500m
+  #   memory: 1.5G
+nodeSelector: {}
+tolerations: []


### PR DESCRIPTION
## Description

- taken from https://docs.aquasec.com/docs/tm-deploy#section-deployment-kubernetes-hosts
  and modified for usage with Helm

- also standardized against existing Charts in the repo
  - use same LICENSE and .helmignore
  - use same ServiceAccount and image pull Secret
  - use same port protocol (TCP)
  - don't specify `LoadBalancer` as Service `type`
  - use same set of metadata and template metadata for all resources
  - use same values to define livenessProbe, readinessProbe, resources,
    nodeSelector, affinity, and tolerations
  - use same values to define image and imageCredentials
  - use similar Chart.yaml, NOTES.txt, _helpers.tpl, values.yaml, and
    README.md

- add Tenant Manager to repo root README

## Review Notes

- I used "5.0.0" as that's what the other Charts use, but maybe this should be a more alpha version initially
- Resources for Tenant Manager aren't specified in [the sizing guide](https://docs.aquasec.com/docs/sizing-guide#section-recommendations), so I'm not sure what to put in the commented out section in `values.yaml`, those were just copied from another Chart and therefore are arbitrary for Tenant Manager.
- I'm guessing there should probably be more `values` for customizing the DB access, but I'm not sure what those should look like

Please feel free to iterate on top of any of that.

The README table change may conflict with my other PR around formatting: #97 