### PR TITLE
Incorrect parentheses

### DIFF
--- a/server/templates/db-pvc.yaml
+++ b/server/templates/db-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and ((not .Values.db.external.enabled) .Values.db.persistence.enabled) }}
+{{- if and (not .Values.db.external.enabled) (.Values.db.persistence.enabled) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/server/templates/web-secrets.yaml
+++ b/server/templates/web-secrets.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.admin.secretname }}
-{{- if or (( .Values.admin.password) .Values.admin.token) }}
+{{- if or (.Values.admin.password) (.Values.admin.token) }}
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Synopsis:
The misplaced opening parentethesis on these lines convert logical boolean association to attempted function calls -- as these are variable values, and not functions, the functions calls cause errors

Details:
I'm using helm 3.2.4
```
$ helm version
version.BuildInfo{Version:"v3.2.4", GitCommit:"0ad800ef43d3b826f31a5ad8dfbb4fe05d143688", GitTreeState:"dirty", GoVersion:"go1.14.3"}
```

On straight checkout of repo, I try to template the `server/` manifests but I get errors:
```
$ helm template foo server/
Error: template: server/templates/web-secrets.yaml:2:11: executing "server/templates/web-secrets.yaml" at <(.Values.admin.password) .Values.admin.token>: can't give argument to non-function .Values.admin.password
```
```
$ helm template foo server/ --set imageCredentials.username=foo --set imageCredentials.password=foo
Error: template: server/templates/db-pvc.yaml:1:12: executing "server/templates/db-pvc.yaml" at <(not .Values.db.external.enabled) .Values.db.persistence.enabled>: can't give argument to non-function not .Values.db.external.enabled
```

With these changes, the templates are now interpolated:
```
$ helm template foo server/ --set imageCredentials.username=foo --set imageCredentials.password=foo
---
# Source: server/templates/rbac.yaml
apiVersion: policy/v1beta1
< ...elided... >
```