### PR TITLE
Allow common image tag

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -72,6 +72,7 @@ Parameter | Description | Default
 `admin.passwordkey` | administrator password key in the secret | `null`
 `docker.socket.path` | docker socket path | `/var/run/docker.sock`
 `docker` | Scanning mode direct or docker [link](https://docs.aquasec.com/docs/scanning-mode#default-scanning-mode) | `-`
+`common.image.tag` | Images are commonly in lockstep; use this value if a <component>.image.tag is not set | `5.0`
 `db.external.enabled` | Avoid installing a Postgres container and use an external database instead | `false`
 `db.external.name` | PostgreSQL DB name | `unset`
 `db.external.host` | PostgreSQL DB hostname | `unset`
@@ -102,7 +103,7 @@ Parameter | Description | Default
 `db.persistence.size` |	Persistent Volume size | `30Gi`
 `db.persistence.storageClass` |	Persistent Volume Storage Class | `unset`
 `db.image.repository` | the docker image name to use | `database`
-`db.image.tag` | The image tag to use. | `5.0`
+`db.image.tag` | The image tag to use. | `unset`
 `db.image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`
 `db.service.type` | k8s service type | `ClusterIP`
 `db.resources` |	Resource requests and limits | `{}`
@@ -110,7 +111,7 @@ Parameter | Description | Default
 `db.tolerations` |	Kubernetes node tolerations	| `[]`
 `db.affinity` |	Kubernetes node affinity | `{}`
 `gate.image.repository` | the docker image name to use | `gateway`
-`gate.image.tag` | The image tag to use. | `5.0`
+`gate.image.tag` | The image tag to use. | `unset`
 `gate.image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`
 `gate.service.type` | k8s service type | `ClusterIP`
 `gate.service.externalPort` | k8s service type | `3622`
@@ -124,7 +125,7 @@ Parameter | Description | Default
 `gate.tolerations` |	Kubernetes node tolerations	| `[]`
 `gate.affinity` |	Kubernetes node affinity | `{}`
 `web.image.repository` | the docker image name to use | `console`
-`web.image.tag` | The image tag to use. | `5.0`
+`web.image.tag` | The image tag to use. | `unset`
 `web.image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`
 `web.service.type` | k8s service type | `LoadBalancer`
 `web.service.externalPort` | k8s service type | `8080`

--- a/server/templates/db-deployment.yaml
+++ b/server/templates/db-deployment.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccount: {{ .Release.Name }}-sa
       containers:
       - name: db
-        image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.db.image.repository }}:{{ .Values.db.image.tag }}"
+        image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.db.image.repository }}:{{ or .Values.db.image.tag .Values.common.image.tag }}"
         imagePullPolicy: "{{ .Values.db.image.pullPolicy }}"
         env:
           {{- if .Values.db.passwordSecret }}

--- a/server/templates/gate-deployment.yaml
+++ b/server/templates/gate-deployment.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccount: {{ .Release.Name }}-sa
       containers:
       - name: gate
-        image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.gate.image.repository }}:{{ .Values.gate.image.tag }}"
+        image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.gate.image.repository }}:{{ or .Values.gate.image.tag .Values.common.image.tag }}"
         imagePullPolicy: "{{ .Values.gate.image.pullPolicy }}"
         env:
         - name: AQUA_CONSOLE_SECURE_ADDRESS

--- a/server/templates/web-deployment.yaml
+++ b/server/templates/web-deployment.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccount: {{ .Release.Name }}-sa
       containers:
       - name: web
-        image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
+        image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.web.image.repository }}:{{ or .Values.web.image.tag .Values.common.image.tag }}"
         imagePullPolicy: "{{ .Values.web.image.pullPolicy }}"
         env:
         - name: SCALOCK_DBUSER

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -29,6 +29,10 @@ docker:
 
 docker:
 
+common:
+  image:
+    tag: "5.0"
+
 db:
   external:
     enabled: false


### PR DESCRIPTION
I expect to keep all the images in lockstep, so specifying tag versions separately seems an anti-pattern.  This change allows them to be easily kept in sync by taking their common config value from one line.  It retains the ability to set them separately if needed.