### PR TITLE
docs/fix: use correct default secret name in imagepullsecret docs

### DIFF
--- a/docs/imagepullsecret.md
+++ b/docs/imagepullsecret.md
@@ -11,7 +11,7 @@ kubectl create namespace aqua
 2. Create the image pull secret:
 
 ```bash
-kubectl create secret docker-registry aqua-registry --docker-server="registry.aquasec.com" --namespace aqua --docker-username="user@example.com" --docker-password="<Password>" --docker-email="user@example.com"
+kubectl create secret docker-registry aqua-registry-secret --docker-server="registry.aquasec.com" --namespace aqua --docker-username="user@example.com" --docker-password="<Password>" --docker-email="user@example.com"
 ```
 
 > Note: in case you using the csp chart the chart can create the image pull secret automaticly.


### PR DESCRIPTION
## Description

- it used the name "aqua-registry" instead of "aqua-registry-secret",
  but the latter is the actual default
  - c.f. https://github.com/aquasecurity/aqua-helm/blob/d40a42a8a3682255b72e0a484d381f5a94962eb5/server/values.yaml#L4,
    https://github.com/aquasecurity/aqua-helm/blob/d40a42a8a3682255b72e0a484d381f5a94962eb5/docs/imagepullsecret.md#L25,
    https://github.com/aquasecurity/aqua-helm/blob/d40a42a8a3682255b72e0a484d381f5a94962eb5/enforcer/values.yaml#L3,
    https://github.com/aquasecurity/aqua-helm/blob/d40a42a8a3682255b72e0a484d381f5a94962eb5/enforcer/README.md#L34
    - mistake seems to be from 38f48d607ca6fbda0cb29a154df9f47d3ce8bd15

- encountered this live during an onboarding call with Aqua engineers

## Review Notes

Wasted a good bit of my time and all the Aqua folks on the call's time getting this right... 😐 