### PR TITLE
docs: clarify setting imageCredentials.create: false

### DIFF
--- a/docs/imagepullsecret.md
+++ b/docs/imagepullsecret.md
@@ -16,15 +16,11 @@ kubectl create secret docker-registry aqua-registry --docker-server="registry.aq
 
 > Note: in case you using the csp chart the chart can create the image pull secret automaticly.
 
-after creating the secret you should set in the values to not create pull image secret by setting up in values.yaml file
-set create as `false` and the name as the name of the secret you create:
+3. After creating the secret manually, you should set the chart to not create one:
+
+`values.yaml`:
 
 ```yaml
 imageCredentials:
   create: false
-  name: aqua-registry-secret
-  repositoryUriPrefix: "registry.aquasec.com" 
-  registry: "registry.aquasec.com"
-  username: ""
-  password: ""
 ```


### PR DESCRIPTION
## Description

- you don't need to specify name, repositoryUriPrefix, registry,
  username, or password if you follow the steps here in this doc
  - it was quite confusing why it listed all those when none of them
    are required, they're optional and are only necessary if you
    create a different secret that doesn't follow the directions here

- fix and simplify repetitive run-on sentence
- specify that this is step 3.
  - previously was unspecified and almost seemed optional if one were
    skimming the doc, which is otherwise numbered

- this was something I noticed before but was also noted during a live
  call with Aqua engineers

## Tags

Related to #103 