### PR TITLE
docs: consistently link to docs/imagepullsecret.md in all charts

### DIFF
--- a/enforcer/README.md
+++ b/enforcer/README.md
@@ -19,19 +19,7 @@ These are Helm charts for installation and maintenance of Aqua Container Securit
 
 ### Container Registry Credentials
 
-The Aqua server (Console and Gateway) components are available in our private repository, which requires authentication. By default, the charts create a secret based on the values.yaml. 
-
-First, create a new namespace named "aqua":
-
-```bash
-kubectl create namespace aqua
-```
-
-Next, **(Optional)** create the secret:
-
-```bash
-kubectl create secret docker-registry aqua-registry-secret  --docker-server="registry.aquasec.com" --namespace aqua --docker-username="jg@example.com" --docker-password="Truckin" --docker-email="jg@example.com"
-```
+[Link](../docs/imagepullsecret.md)
 
 ## Installing the Chart
 

--- a/kube-enforcer/README.md
+++ b/kube-enforcer/README.md
@@ -8,14 +8,21 @@ These are Helm charts for installation and maintenance of Aqua Container Securit
 
 - [Aqua Security Kube Enforcer Helm Chart](#aqua-security-kube-enforcer-helm-chart)
   - [Contents](#contents)
-  - [Configure TLS Authentication to the API Server](#optional-configure-tls-authentication-to-the-api-server)
-  - [Deploy The Helm Chart](#deploy-the-helm-chart)
-    - [Installing the Chart](#installing-the-chart)
+  - [Prerequisites](#prerequisites)
+    - [Container Registry Credentials](#container-registry-credentials)
+    - [Configure TLS Authentication to the API Server](#optional-configure-tls-authentication-to-the-api-server)
+  - [Installing the Chart](#installing-the-chart)
   - [Configurable Variables](#configurable-variables)
     - [KubeEnforcer](#kubeenforcer)
   - [Issues and feedback](#issues-and-feedback)
 
-## Configure TLS Authentication between KubeEnforcer & API Server
+## Prerequisites
+
+### Container Registry Credentials
+
+[Link](../docs/imagepullsecret.md)
+
+### Configure TLS Authentication between KubeEnforcer & API Server
 
 You need to enable TLS authentication from the API Server to the Kube-Enforcer. Perform these steps:
 
@@ -24,7 +31,7 @@ You need to enable TLS authentication from the API Server to the Kube-Enforcer. 
 ```shell
 openssl genrsa -out ca.key 2048
 openssl req -x509 -new -nodes -key ca.key -days 100000 -out ca.crt -subj "/CN=admission_ca"
-    
+
 cat >server.conf <<EOF
 [req]
 req_extensions = v3_req
@@ -35,7 +42,7 @@ basicConstraints = CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth, serverAuth
 EOF
-    
+
 openssl genrsa -out server.key 2048
 openssl req -new -key server.key -out server.csr -subj "/CN=aqua-kube-enforcer.aqua.svc" -config server.conf
 openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 100000 -extensions v3_req -extfile server.conf
@@ -43,17 +50,7 @@ openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out s
 
 You also also use your own certificates without generating new ones for TLS authentication all we need is root CA certificate, certificate signed by CA and certificate key.
 
-## Deploy The Helm Chart
-
-**(Optional)** create the secret:
-
-```bash
-kubectl create secret docker-registry aqua-image-pull-secret --docker-server="registry.aquasec.com" --namespace aqua --docker-username="jg@example.com" --docker-password="Truckin" --docker-email="jg@example.com"
-```
-
-If you are creating the registry secret by following the above step. Change the ```imageCredentials.create``` to ```false``` in ```values.yaml``` file this makes sure helm chart will not attempt to create registry secret again and update the ```imageCredentials.name``` with the name of the secret created.
-
-### Installing the Chart
+## Installing the Chart
 
 Clone the GitHub repository with the charts
 
@@ -71,7 +68,7 @@ Optional flags:
 
 ```
 --namespace                              default to aqua
---aquaSecret.kubeEnforcerToken           default to "" you can find the KubeEnforcer token from aqua csp under enforcers tab in default/custom KubeEnforcer group or you can manually approve KubeEnforcer authentication from aqua CSP under default/custom KubeEnforcer group in enforcers tab. 
+--aquaSecret.kubeEnforcerToken           default to "" you can find the KubeEnforcer token from aqua csp under enforcers tab in default/custom KubeEnforcer group or you can manually approve KubeEnforcer authentication from aqua CSP under default/custom KubeEnforcer group in enforcers tab.
 ```
 
 ## Configurable Variables

--- a/scanner/README.md
+++ b/scanner/README.md
@@ -8,10 +8,18 @@ These are Helm charts for installation and maintenance of Aqua Container Securit
 
 - [Aqua Security Scanner Helm Chart](#aqua-security-scanner-helm-chart)
   - [Contents](#contents)
+  - [Prerequisites](#prerequisites)
+    - [Container Registry Credentials](#container-registry-credentials)
   - [Installing the Chart](#installing-the-chart)
   - [Configurable Variables](#configurable-variables)
     - [Scanner](#scanner)
   - [Issues and feedback](#issues-and-feedback)
+
+## Prerequisites
+
+### Container Registry Credentials
+
+[Link](../docs/imagepullsecret.md)
 
 ## Installing the Chart
 


### PR DESCRIPTION
## Description

- server already uses the link
- enforcer had the "Container Registry Credentials" section but didn't
  use the link
  - now it just links out
- kubeenforcer mentioned this, but in a differently named "Deploy The
  Helm Chart"
  - that section was removed and "Installing the Chart" was moved up
    a level consistent with every other chart
  - "Prerequisites" section was created with "Container Registry
    Credentials" under it with the link
    - TLS auth section was moved under it as well since it too is
      a prereq
- scanner didn't even mention imagepullsecret
  - so created "Prerequisites" and "Container Registry Credentials"
    sections with the link

## Tags

I would specifically only merge this after #103 has been merged, because that fixes a bug in that doc that other docs don't have.