### PR TITLE
docs: consistently use "Issues and feedback" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ CSP deployments include the following components:
   - [Ingress](#ingress)
   - [Deploy the Helm charts](#deploy-the-helm-charts)
 - [Troubleshooting](#troubleshooting)
-- [Support](#support)
+- [Issues and feedback](#issues-and-feedback)
 
 ## Helm charts
 
@@ -182,6 +182,6 @@ for more information go to storage docs, [Link](docs/storage.md)
   kubectl apply -f pv-example.yaml
   ```
 
-# Support
+## Issues and feedback
 
-If you encounter any problems, or would like to give us feedback, we encourage you to raise issues here on GitHub. Please contact us at https://github.com/aquasecurity.
+If you encounter any problems or would like to give us feedback on deployments, we encourage you to raise issues here on GitHub.

--- a/enforcer/README.md
+++ b/enforcer/README.md
@@ -10,7 +10,7 @@ These are Helm charts for installation and maintenance of Aqua Container Securit
   - [Contents](#contents)
   - [Prerequisites](#prerequisites)
     - [Container Registry Credentials](#container-registry-credentials)
-  - [Installing the Charts](#installing-the-charts)
+  - [Installing the Chart](#installing-the-chart)
   - [Configurable Variables](#configurable-variables)
     - [Enforcer](#enforcer)
   - [Issues and feedback](#issues-and-feedback)
@@ -33,7 +33,7 @@ Next, **(Optional)** create the secret:
 kubectl create secret docker-registry aqua-registry-secret  --docker-server="registry.aquasec.com" --namespace aqua --docker-username="jg@example.com" --docker-password="Truckin" --docker-email="jg@example.com"
 ```
 
-## Installing the Charts
+## Installing the Chart
 
 Clone the GitHub repository with the charts
 

--- a/enforcer/README.md
+++ b/enforcer/README.md
@@ -14,7 +14,6 @@ These are Helm charts for installation and maintenance of Aqua Container Securit
   - [Configurable Variables](#configurable-variables)
     - [Enforcer](#enforcer)
   - [Issues and feedback](#issues-and-feedback)
-  - [Support](#support)
 
 ## Prerequisites
 
@@ -76,7 +75,3 @@ Parameter | Description | Default
 ## Issues and feedback
 
 If you encounter any problems or would like to give us feedback on deployments, we encourage you to raise issues here on GitHub.
-
-## Support
-
-If you encounter any problems or would like to give us feedback on deployments, we encourage you to raise issues here on GitHub please contact us at https://github.com/aquasecurity.

--- a/kube-enforcer/README.md
+++ b/kube-enforcer/README.md
@@ -74,12 +74,12 @@ Optional flags:
 | `imageCredentials.name`               | Your Docker pull image secret name    | `aqua-image-pull-secret`                                                                   |
 | `imageCredentials.username`               | Your Docker registry (DockerHub, etc.) username    | `N/A`                                                                   |
 | `imageCredentials.password`               | Your Docker registry (DockerHub, etc.) password    | `N/A`
-| `aquaSecret.kubeEnforcerToken`                           | Aqua KubeEnforcer token    | `N/A`    
+| `aquaSecret.kubeEnforcerToken`                           | Aqua KubeEnforcer token    | `N/A`
 | `certsSecret.serverCertificate`                           | Certificate for TLS authentication with Kubernetes api-server    | `N/A`
 | `certsSecret.serverKey`                           | Certificate key for TLS authentication with Kubernetes api-server    | `N/A`
 | `validatingWebhook.caBundle`                           | Root Certificate for TLS authentication with Kubernetes api-server   | `N/A`                                                 |
 | `envs.gatewayAddress`                          | Gateway host Address    | `aqua-gateway:8443`                                                     |
- 
+
 
 ## Issues and feedback
 

--- a/scanner/README.md
+++ b/scanner/README.md
@@ -11,8 +11,8 @@ These are Helm charts for installation and maintenance of Aqua Container Securit
   - [Installing the Chart](#installing-the-chart)
   - [Configurable Variables](#configurable-variables)
     - [Scanner](#scanner)
-  - [Support](#support)
-  
+  - [Issues and feedback](#issues-and-feedback)
+
 ## Installing the Chart
 
 Clone the GitHub repository with the chart
@@ -51,6 +51,6 @@ Parameter | Description | Default
 `tolerations` |	Kubernetes node tolerations	| `[]`
 `affinity` |	Kubernetes node affinity | `{}`
 
-## Support
+## Issues and feedback
 
-If you encounter any problems or would like to give us feedback on deployments, we encourage you to raise issues here on GitHub please contact us at https://github.com/aquasecurity.
+If you encounter any problems or would like to give us feedback on deployments, we encourage you to raise issues here on GitHub.

--- a/server/README.md
+++ b/server/README.md
@@ -12,6 +12,7 @@ These are Helm charts for installation and maintenance of Aqua Container Securit
   - [PostgreSQL database](#postgresql-database)
 - [Installing the Chart](#installing-the-chart)
 - [Configurable Variables](#configurable-variables)
+- [Issues and feedback](#issues-and-feedback)
 
 ## Prerequisites
 
@@ -141,6 +142,6 @@ Parameter | Description | Default
 `web.ingress.hosts` | Ingress hostnames |	`[]`
 `web.ingress.tls` |	Ingress TLS configuration (YAML) | `[]`
 
-## Support
+## Issues and feedback
 
-If you encounter any problems or would like to give us feedback on deployments, we encourage you to raise issues here on GitHub please contact us at https://github.com/aquasecurity.
+If you encounter any problems or would like to give us feedback on deployments, we encourage you to raise issues here on GitHub.


### PR DESCRIPTION
## Description

- kube enforcer uses an "Issues and feedback" section and no
  "Support" section
  - I think this section is clearer than "Support"; I assume a "Support"
    section may link to a customer service email or ticketing system,
    not to standard GitHub issues
- enforcer had both an "Issues and feedback" section _and_ a "Support"
  section
  - remove the duplicative "Support" section
- server had a "Support" section but wasn't linked in ToC
  - add "Issues and feedback" and link in ToC
- scanner had a "Support" section
  - change to "Issues and feedback"
- main repo root README had a "Support" section
  - change to "Issues and feedback"
  - also fix heading to be an H2 as only one H1 is semantically allowed
    per page
    - and all other docs use an H2 for this section

## Tags

Related to #105 and #108 , just a lot of consistency issues in general. In this case, unlike #105, they're not harmful and have low impact, but generally good to be consistent anyway.