### PR TITLE
fix/docs: dated TLS auth link in KubeEnforcer docs' ToC

### DIFF
--- a/kube-enforcer/README.md
+++ b/kube-enforcer/README.md
@@ -2,7 +2,7 @@
 
 Contents:
 - [Aqua Kube Enforcer Helm Chart](#aqua-kube-enforcer-helm-chart)
-  - [Configure TLS Authentication to the API Server](#optional-configure-tls-authentication-to-the-api-server)
+  - [Configure TLS Authentication between KubeEnforcer & API Server](#configure-tls-authentication-between-kubeenforcer-&-api-server)
   - [Deploy The Helm Chart](#deploy-the-helm-chart)
     - [Installing the Chart](#installing-the-chart)
   - [Issues and feedback](#issues-and-feedback)


### PR DESCRIPTION
## Description

- 2d3b1eb109ab447f8453e5c21de34073cb170c64 changed the heading slightly,
  but didn't change the respective entry in the ToC
  - this updates the ToC entry to match the heading

## Tags

Follow-up to #93