### PR TITLE
docs: update KubeEnforcer docs to be consistent with others

### DIFF
--- a/kube-enforcer/README.md
+++ b/kube-enforcer/README.md
@@ -1,10 +1,18 @@
-# Aqua Kube Enforcer Helm Chart
+<img src="https://avatars3.githubusercontent.com/u/12783832?s=200&v=4" height="100" width="100" /><img src="https://avatars3.githubusercontent.com/u/15859888?s=200&v=4" width="100" height="100"/>
 
-Contents:
-- [Aqua Kube Enforcer Helm Chart](#aqua-kube-enforcer-helm-chart)
+# Aqua Security Kube Enforcer Helm Chart
+
+These are Helm charts for installation and maintenance of Aqua Container Security Enforcer
+
+## Contents
+
+- [Aqua Security Kube Enforcer Helm Chart](#aqua-security-kube-enforcer-helm-chart)
+  - [Contents](#contents)
   - [Configure TLS Authentication to the API Server](#optional-configure-tls-authentication-to-the-api-server)
   - [Deploy The Helm Chart](#deploy-the-helm-chart)
     - [Installing the Chart](#installing-the-chart)
+  - [Configurable Variables](#configurable-variables)
+    - [KubeEnforcer](#kubeenforcer)
   - [Issues and feedback](#issues-and-feedback)
 
 ## Configure TLS Authentication between KubeEnforcer & API Server
@@ -66,7 +74,9 @@ Optional flags:
 --aquaSecret.kubeEnforcerToken           default to "" you can find the KubeEnforcer token from aqua csp under enforcers tab in default/custom KubeEnforcer group or you can manually approve KubeEnforcer authentication from aqua CSP under default/custom KubeEnforcer group in enforcers tab. 
 ```
 
-### Customize your configuration
+## Configurable Variables
+
+### KubeEnforcer
 
 | Parameter                         | Description                          | Default                                                                      |
 | --------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------- |


### PR DESCRIPTION
## Description

- have an Aqua image at the top
- say "Aqua Security" for heading, not just "Aqua"
- have a one-line description of the Chart
- use a "Contents" section
  - not just "Contents:" text
  - and link to it in ToC
- use a "Configurable Variables" section
  - not a "Customize your configuration section"
  - and add a "KubeEnforcer" subsection
  - and add links to both in ToC

- all the other charts already do this, KubeEnforcer was the odd one out

# Tags

Related to #106 and #105 in adding consistency. The differences in consistency tripped me up when writing #99 as well