### PR TITLE
fix/docs: dated TLS auth link in KubeEnforcer docs' ToC

### DIFF
--- a/kube-enforcer/README.md
+++ b/kube-enforcer/README.md
@@ -10,7 +10,7 @@ These are Helm charts for installation and maintenance of Aqua Container Securit
   - [Contents](#contents)
   - [Prerequisites](#prerequisites)
     - [Container Registry Credentials](#container-registry-credentials)
-    - [Configure TLS Authentication to the API Server](#optional-configure-tls-authentication-to-the-api-server)
+    - [Configure TLS Authentication between KubeEnforcer & API Server](#configure-tls-authentication-between-kubeenforcer-&-api-server)
   - [Installing the Chart](#installing-the-chart)
   - [Configurable Variables](#configurable-variables)
     - [KubeEnforcer](#kubeenforcer)


### PR DESCRIPTION
- 2d3b1eb109ab447f8453e5c21de34073cb170c64 changed the heading slightly,
  but didn't change the respective entry in the ToC
  - this updates the ToC entry to match the heading