### PR TITLE
fix: consistent imageCredentials in KubeEnforcer

### DIFF
--- a/kube-enforcer/README.md
+++ b/kube-enforcer/README.md
@@ -77,8 +77,10 @@ Optional flags:
 
 | Parameter                         | Description                          | Default                                                                      |
 | --------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------- |
-| `imageCredentials.create`               | Set if to create new pull image secret    | `true`                                                                 |
-| `imageCredentials.name`               | Your Docker pull image secret name    | `aqua-image-pull-secret`                                                                   |
+| `imageCredentials.create` | Set if to create new pull image secret | `false`
+| `imageCredentials.name` | Your Docker pull image secret name | `aqua-registry-secret`
+| `imageCredentials.repositoryUriPrefix` | repository uri prefix for dockerhub set `docker.io` | `registry.aquasec.com`
+| `imageCredentials.registry` | set the registry url for dockerhub set `index.docker.io/v1/` | `registry.aquasec.com`
 | `imageCredentials.username`               | Your Docker registry (DockerHub, etc.) username    | `N/A`                                                                   |
 | `imageCredentials.password`               | Your Docker registry (DockerHub, etc.) password    | `N/A`
 | `aquaSecret.kubeEnforcerToken`                           | Aqua KubeEnforcer token    | `N/A`

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -1,13 +1,11 @@
 # Specifies the secret data for imagePullSecrets needed to fetch the private docker images
 imageCredentials:
-  # If aqua-registry already exists in the cluster. Make create to false. So it won't attempt to create a new registry secret. 
-  create: true
-  name: csp-registry-secret # example
+  create: false
+  name: aqua-registry-secret # When create is false please specify
   repositoryUriPrefix: "registry.aquasec.com" # for dockerhub - "docker.io"
   registry: "registry.aquasec.com" #REQUIRED only if create is true, for dockerhub - "index.docker.io/v1/"
   username: ""
   password: ""
-  email: "example@gmail.com"
 
 managed: false
 environment: aws # aws, acs, onprem


### PR DESCRIPTION
## Description

- KubeEnforcer used a different, older imagePullSecret name than the
  other charts
  - this would cause bugs and result in the image being unable to be
    pulled if one followed the directions and used the
    aqua-registry-secret name
  - 38f48d607ca6fbda0cb29a154df9f47d3ce8bd15 changed it from
    csp-registry-secret to aqua-registry-secret
  - and the docs said the default was aqua-image-pull-secret, which
    wasn't what it was set to nor the new name, it was neither
    - seemed like the Enforcer used this incorrect name in its docs
      until 38f48d607ca6fbda0cb29a154df9f47d3ce8bd15 as well

- the create default was set to true, but is false in the other charts,
  so this sets it to false to make it consistent
- it also specified an email for some reason, while none of the other
  charts do so
- docs didn't specify repositoryUriPrefix or registry, but Enforcer
  and Server do, so add those for consistency
  - also because it's a bit misleading and confusing to not add _all_
    the configurable values in the docs if a "see more in values.yaml"
    or something isn't specified

## Tags

38f48d607ca6fbda0cb29a154df9f47d3ce8bd15 changed the secret name in charts per the description.
Fixes inconsistencies introduced in #86, #93, and #94

Like #103, which also made a correction to the imagePullSecret naming, this type of bug is really easy to hit, get confused by, and spend a lot of unnecessary time on

## Review Notes

This is a bugfix but is technically slightly breaking as well for anyone that relied on previous behavior. The KubeEnforcer chart still has yet to be published per #96 though