### PR TITLE
fix/docs: imageCredentials.username is unset in all charts

### DIFF
--- a/enforcer/README.md
+++ b/enforcer/README.md
@@ -44,7 +44,7 @@ Parameter | Description | Default
 `imageCredentials.name` | Your Docker pull image secret name | `aqua-registry-secret`
 `imageCredentials.repositoryUriPrefix` | repository uri prefix for dockerhub set `docker.io` | `registry.aquasec.com`
 `imageCredentials.registry` | set the registry url for dockerhub set `index.docker.io/v1/` | `registry.aquasec.com`
-`imageCredentials.username` | Your Docker registry (DockerHub, etc.) username | `aqua-registry-secret`
+`imageCredentials.username` | Your Docker registry (DockerHub, etc.) username | `unset`
 `imageCredentials.password` | Your Docker registry (DockerHub, etc.) password | `unset`
 `privileged` | determines if any container in a pod can enable privileged mode. | `true`
 `hostRunPath` |	for changing host run path for example for pks need to change to /var/vcap/sys/run/docker	| `unset`

--- a/server/README.md
+++ b/server/README.md
@@ -59,7 +59,7 @@ Parameter | Description | Default
 `imageCredentials.name` | Your Docker pull image secret name | `aqua-registry-secret`
 `imageCredentials.repositoryUriPrefix` | repository uri prefix for dockerhub set `docker.io` | `registry.aquasec.com`
 `imageCredentials.registry` | set the registry url for dockerhub set `index.docker.io/v1/` | `registry.aquasec.com`
-`imageCredentials.username` | Your Docker registry (DockerHub, etc.) username | `aqua-registry-secret`
+`imageCredentials.username` | Your Docker registry (DockerHub, etc.) username | `unset`
 `imageCredentials.password` | Your Docker registry (DockerHub, etc.) password | `unset`
 `rbac.enabled` | if to create rbac configuration for aqua | `true`
 `rbac.privileged` | determines if any container in a pod can enable privileged mode. | `true`


### PR DESCRIPTION
## Description

- none of the charts' values.yaml files specify username, it is empty
  in all of them
  - but the docs in Server and Enforcer said the default username was
    aqua-registry-secret, which was incorrect
    - so fixed the docs to say it is unset

- bug was introduced in 38f48d607ca6fbda0cb29a154df9f47d3ce8bd15,
  prior to that the default was specified as "N/A"

## Tags

This docs bug was introduced in 38f48d607ca6fbda0cb29a154df9f47d3ce8bd15