### PR TITLE
security: consistently use imagePullPolicy: Always

### DIFF
--- a/enforcer/README.md
+++ b/enforcer/README.md
@@ -54,7 +54,7 @@ Parameter | Description | Default
 `gate.port` | gateway port | `8443`
 `image.repository` | the docker image name to use | `enforcer`
 `image.tag` | The image tag to use. | `5.0`
-`image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`
+`image.pullPolicy` | The kubernetes image pull policy. | `Always`
 `resources` |	Resource requests and limits | `{}`
 `nodeSelector` |	Kubernetes node selector	| `{}`
 `tolerations` |	Kubernetes node tolerations	| `[]`

--- a/enforcer/values.yaml
+++ b/enforcer/values.yaml
@@ -25,7 +25,7 @@ gate:
 image:
   repository: enforcer
   tag: "5.0"
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 livenessProbe: {}
 readinessProbe: {}

--- a/scanner/README.md
+++ b/scanner/README.md
@@ -50,7 +50,7 @@ Parameter | Description | Default
 `server.port` | service port for server to connect | `8080`
 `image.repository` | the docker image name to use | `scanner`
 `image.tag` | The image tag to use. | `5.0`
-`image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`
+`image.pullPolicy` | The kubernetes image pull policy. | `Always`
 `user` | scanner username | `unset`
 `password` | scanner password | `unset`
 `replicaCount` | replica count | `1`

--- a/scanner/values.yaml
+++ b/scanner/values.yaml
@@ -14,7 +14,7 @@ server:
 image:
   repository: scanner
   tag: "5.0"
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 user:
 password:

--- a/server/README.md
+++ b/server/README.md
@@ -104,7 +104,7 @@ Parameter | Description | Default
 `db.persistence.storageClass` |	Persistent Volume Storage Class | `unset`
 `db.image.repository` | the docker image name to use | `database`
 `db.image.tag` | The image tag to use. | `5.0`
-`db.image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`
+`db.image.pullPolicy` | The kubernetes image pull policy. | `Always`
 `db.service.type` | k8s service type | `ClusterIP`
 `db.resources` |	Resource requests and limits | `{}`
 `db.nodeSelector` |	Kubernetes node selector	| `{}`
@@ -112,7 +112,7 @@ Parameter | Description | Default
 `db.affinity` |	Kubernetes node affinity | `{}`
 `gate.image.repository` | the docker image name to use | `gateway`
 `gate.image.tag` | The image tag to use. | `5.0`
-`gate.image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`
+`gate.image.pullPolicy` | The kubernetes image pull policy. | `Always`
 `gate.service.type` | k8s service type | `ClusterIP`
 `gate.service.externalPort` | k8s service type | `3622`
 `gate.service.nodePort` | k8s service type | `unset`
@@ -126,7 +126,7 @@ Parameter | Description | Default
 `gate.affinity` |	Kubernetes node affinity | `{}`
 `web.image.repository` | the docker image name to use | `console`
 `web.image.tag` | The image tag to use. | `5.0`
-`web.image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`
+`web.image.pullPolicy` | The kubernetes image pull policy. | `Always`
 `web.service.type` | k8s service type | `LoadBalancer`
 `web.service.externalPort` | k8s service type | `8080`
 `web.service.nodePort` | k8s service type | `unset`

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -59,7 +59,7 @@ db:
   image:
     repository: database
     tag: "5.0"
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   service:
     type: ClusterIP
   persistence:
@@ -101,7 +101,7 @@ gate:
   image:
     repository: gateway
     tag: "5.0"
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   service:
     type: ClusterIP
     externalPort: 3622
@@ -129,7 +129,7 @@ web:
   image:
     repository: console
     tag: "5.0"
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   service:
     type: LoadBalancer
     externalPort: 8080


### PR DESCRIPTION
## Description

- previously only KubeEnforcer had Always, the rest had IfNotPresent

- Always ensures that the imagePullSecret is always checked for
  validity, while IfNotPresent allows for an image to be used if it is
  already cached on the node, even if the secret is no longer valid

- And Docker will *not* actually re-download the image if it's already
  on the node, as the hashes will match, so it's not much less
  efficient, but is more secure

## Review Notes

[This blog post](https://trstringer.com/kubernetes-alwayspullimages/) talks about why `Always` is good to use for security, as does the official [`AlwaysPullImages` Admission Controller docs](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#alwayspullimages) that it links to.

[The official container images docs](https://kubernetes.io/docs/concepts/configuration/overview/#container-images) specifies how it is `Always` is still very efficient due to caching
