### PR TITLE
docs: clarify difference between clustermode and activeactive

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -64,8 +64,8 @@ Parameter | Description | Default
 `rbac.enabled` | if to create rbac configuration for aqua | `true`
 `rbac.privileged` | determines if any container in a pod can enable privileged mode. | `true`
 `rbac.roleRef` | name of rbac role to set in not create by helm | `unset`
-`activeactive` |	set in active active mode | `false`
-`clustermode` |	set in HA cluster mode | `false`
+`activeactive` | set for HA Active-Active cluster mode | `false`
+`clustermode` | set for HA Active-Passive cluster mode <br> To be deprecated, use Active-Active instead | `false`
 `admin.token`| Use this Aqua license token | `unset`
 `admin.password` | Use this Aqua admin password | `unset`
 `admin.secretname` | use existing secret for admin password and token | `null`

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -13,7 +13,7 @@ rbac:
   roleRef:
 
 # enable only one of the modes
-clustermode: false
+clustermode: false # Active-Passive. To be deprecated, use Active-Active instead
 activeactive: false
 
 admin:


### PR DESCRIPTION
## Description

- clustermode: true is a legacy, to be deprecated option for an HA
  Active-Passive mode
- activeactive: true is a current option for an HA Active-Active mode
  and preferred over Active-Active

- specify this in the README and in values.yaml comment

## Tags

Fixes #98 and fixes #72 which asked a similar question