### PR TITLE
fix: Scanner should have imagePullSecret like other Charts

### DIFF
--- a/scanner/README.md
+++ b/scanner/README.md
@@ -42,10 +42,14 @@ The following table lists the configurable parameters of the Console and Enforce
 
 Parameter | Description | Default
 --------- | ----------- | -------
-`repositoryUriPrefix` | repository uri prefix for dockerhub set `docker.io` | `registry.aquasec.com`
+`imageCredentials.create` | Set if to create new pull image secret | `false`
+`imageCredentials.name` | Your Docker pull image secret name | `aqua-registry-secret`
+`imageCredentials.repositoryUriPrefix` | repository uri prefix for dockerhub set `docker.io` | `registry.aquasec.com`
+`imageCredentials.registry` | set the registry url for dockerhub set `index.docker.io/v1/` | `registry.aquasec.com`
+`imageCredentials.username` | Your Docker registry (DockerHub, etc.) username | `unset`
+`imageCredentials.password` | Your Docker registry (DockerHub, etc.) password | `unset`
 `docker.socket.path` | docker socket path | `/var/run/docker.sock`
 `docker` | Scanning mode direct or docker [link](https://docs.aquasec.com/docs/scanning-mode#default-scanning-mode) | `-`
-`serviceAccount` | k8s service account to use | `aqua-sa`
 `server.serviceName` | service name for server to connect | `aqua-console-svc`
 `server.port` | service port for server to connect | `8080`
 `image.repository` | the docker image name to use | `scanner`

--- a/scanner/templates/_helpers.tpl
+++ b/scanner/templates/_helpers.tpl
@@ -30,3 +30,7 @@ Create chart name and version as used by the chart label.
 {{- define "scanner.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "imagePullSecret" }}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" (required "A valid .Values.imageCredentials.registry entry required!" .Values.imageCredentials.registry) (printf "%s:%s" (required "A valid .Values.imageCredentials.username entry required!" .Values.imageCredentials.username) (required "A valid .Values.imageCredentials.password entry required!" .Values.imageCredentials.password) | b64enc) | b64enc }}
+{{- end }}

--- a/scanner/templates/image-pull-secret.yaml
+++ b/scanner/templates/image-pull-secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.imageCredentials.create -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-registry-secret
+  labels:
+    app: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "imagePullSecret" . }}
+{{- end -}}

--- a/scanner/templates/scanner-deployment.yaml
+++ b/scanner/templates/scanner-deployment.yaml
@@ -23,10 +23,10 @@ spec:
         app: {{ .Release.Name }}-scanner
       name: {{ .Release.Name }}-scanner
     spec:
-      serviceAccount: {{ .Values.serviceAccount }}
+      serviceAccount: {{ .Release.Name }}-sa
       containers:
       - name: scanner
-        image: "{{ .Values.repositoryUriPrefix }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         args:
         - "daemon"

--- a/scanner/templates/serviceaccount.yaml
+++ b/scanner/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-sa
+  labels:
+    app: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+imagePullSecrets:
+{{- if .Values.imageCredentials.create }}
+- name: {{ .Release.Name }}-registry-secret
+{{- else }}
+- name: {{ .Values.imageCredentials.name }}
+{{- end }}

--- a/scanner/values.yaml
+++ b/scanner/values.yaml
@@ -1,4 +1,10 @@
-repositoryUriPrefix: "registry.aquasec.com" # for dockerhub - "docker.io"
+imageCredentials:
+  create: false
+  name: aqua-registry-secret # When create is false please specify
+  repositoryUriPrefix: "registry.aquasec.com" # for dockerhub - "docker.io"
+  registry: "registry.aquasec.com" #REQUIRED only if create is true, for dockerhub - "index.docker.io/v1/"
+  username: ""
+  password: ""
 
 docker:
   socket:
@@ -6,7 +12,6 @@ docker:
 
 docker:
 
-serviceAccount: "aqua-sa"
 server:
   serviceName: "aqua-console-svc" # example
   port: 8080


### PR DESCRIPTION
## Description

- all the other Charts have an imagePullSecret and a ServiceAccount,
  but for some reason Scanner didn't
  - I was able to get it to work without it, but I believe that was by
    chance as one of my Helm installs of a different Chart created a
    ServiceAccount with the same "aqua-sa" name because the Helm Release
    happened to be named "aqua"
    - instead of relying on chance for this, create an imagePullSecret
      and ServiceAccount for the Scanner -- same as all the other
      charts -- ensuring it will always be able to pull
      - remove serviceAccount value as a result

- copy imageCredentials block from one of the other charts
  - this moves repositoryUriPrefix from top-level to
     imageCredentials.repositoryUriPrefix
- copy image-pull-secret.yaml from one of the other charts
- copy serviceaccount.yaml from one of the other charts
- copy `dockerconfig.json` helper into _helpers.tpl from one of the
  other charts

## Tags

It seems to have been like this for a long while (year or two), potentially since origination.

## Review Notes

This is fairly breaking to anyone who used the `serviceAccount` value or `repositoryUriPrefix` but would otherwise not break anything.

## Potential Future Work

The release name happening to work before for the default ServiceAccount also applies to the connection to the Aqua Server. Ideally, there would be a way for that to use the value defined from the Server deploy so it wouldn't need configuration.
I tried creating a wrapper chart of multiple Aqua components when I was installing, but due to manual pieces like getting Scanner `user`/`password` (and Enforcer `enforcerToken`) from Server, it was not possible to install simultaneously with shared values.

I noticed that prior to 19ccc4d2eee6feb8f50733ad428cbfcf83f8f878 Scanner could be installed along with Server which resolves that part, but not anymore.