### PR TITLE
fix/docs: remove imageCredentials.email from root README snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,13 +128,13 @@ cd aqua-helm/
 ### Server chart
 
 ```bash
-helm upgrade --install --namespace aqua aqua ./server --set imageCredentials.username=<>,imageCredentials.password=<>,imageCredentials.email=<>
+helm upgrade --install --namespace aqua aqua ./server --set imageCredentials.username=<>,imageCredentials.password=<>
 ```
 
 ### Enforcer chart
 
 ```bash
-helm upgrade --install --namespace aqua aqua-enforcer ./enforcer --set imageCredentials.username=<>,imageCredentials.password=<>,imageCredentials.email=<>,enforcerToken=<aquasec-token>
+helm upgrade --install --namespace aqua aqua-enforcer ./enforcer --set imageCredentials.username=<>,imageCredentials.password=<>,enforcerToken=<aquasec-token>
 ```
 
 ### KubeEnforcer chart
@@ -146,7 +146,7 @@ helm upgrade --install --namespace aqua kube-enforcer ./kube-enforcer --set imag
 ### Scanner chart (optional)
 
 ```bash
-helm upgrade --install --namespace aqua scanner ./scanner --set imageCredentials.username=<>,imageCredentials.password=<>,imageCredentials.email=<>
+helm upgrade --install --namespace aqua scanner ./scanner --set imageCredentials.username=<>,imageCredentials.password=<>
 ```
 
 # Troubleshooting


### PR DESCRIPTION
## Description

- imageCredentials.email isn't specified or used in any of the Charts,
  so this is extraneous and confusing
- also, imageCredentials.email isn't specified in the Charts' README's
  themselves, only in the root README
  - this might be a good reason to not have subtly different duplicative
    docs in two places, similar to how 38f48d607ca6fbda0cb29a154df9f47d3ce8bd15
    removed the duplicate configuration that was in the root README

## Tags

Seems to have been like this since origination.

Related to #110 which removes an unused `imageCredentials.email` in KubeEnforcer's values