### PR TITLE
feat: add default Scanner user

### DIFF
--- a/scanner/README.md
+++ b/scanner/README.md
@@ -51,7 +51,7 @@ Parameter | Description | Default
 `image.repository` | the docker image name to use | `scanner`
 `image.tag` | The image tag to use. | `5.0`
 `image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`
-`user` | scanner username | `unset`
+`user` | scanner user | `scanner`
 `password` | scanner password | `unset`
 `replicaCount` | replica count | `1`
 `resources` |	Resource requests and limits | `{}`

--- a/scanner/values.yaml
+++ b/scanner/values.yaml
@@ -16,7 +16,7 @@ image:
   tag: "5.0"
   pullPolicy: IfNotPresent
 
-user:
+user: scanner
 password:
 replicaCount: 1
 livenessProbe: {}


### PR DESCRIPTION
## Description

- set to the name "scanner"

- also consistently use "user" in the docs instead of "username"
  - I read "username" and used that in my values in a live call with
    Aqua Engineers, which didn't work since it is actually "user"
    - this should make mistakes and confusion like that harder to happen

## Tags

This will merge conflict with #112 because it changes the line above this 😕 
Ran into the "user" vs. "username" thing right after hitting #103 

## Review Notes

I'm not totally sure why the Scanner `user` and `password` aren't specified as pre-requisites one must create in the docs. If it wasn't for Aqua Engineers telling me on a call, I wouldn't have done that or known to do so until I got the required error.