### PR TITLE
docs: add section on accessing the Server in README and NOTES.txt

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -11,6 +11,7 @@ These are Helm charts for installation and maintenance of Aqua Container Securit
   - [Ingress](#ingress)
   - [PostgreSQL database](#postgresql-database)
 - [Installing the Chart](#installing-the-chart)
+  - [Accessing the Server](#accessing-the-server)
 - [Configurable Variables](#configurable-variables)
 - [Issues and feedback](#issues-and-feedback)
 
@@ -50,6 +51,16 @@ cd aqua-helm/
 ```bash
 helm upgrade --install --namespace aqua aqua ./server --set imageCredentials.username=<>,imageCredentials.password=<>
 ```
+
+### Accessing the Server
+
+With the default values, you can use the following script to access the Server:
+
+```bash
+(echo -n "http://"; kubectl -n aqua get service aqua-console-svc -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'; echo ":8080") | xargs open
+```
+
+If you have not provided a license key or admin user/pass [as values](https://github.com/aquasecurity/aqua-helm/blob/d40a42a8a3682255b72e0a484d381f5a94962eb5/server/values.yaml#L19), then upon first access you will be required to enter your license key and create an admin user and password.
 
 ## Configurable Variables
 

--- a/server/templates/NOTES.txt
+++ b/server/templates/NOTES.txt
@@ -1,9 +1,13 @@
 
 Thank you for installing Aqua Security Server.
 
-Now that you have deployed Aqua Server, you should look over the docs on using: 
+Now that you have deployed Aqua Server, you should look over the docs on using:
 
 https://docs.aquasec.com/docs
 
 
 Your release is named {{ .Release.Name }}.
+
+You can access the Server with:
+
+  $ (echo -n "http://"; kubectl -n {{ . Release.Namespace }} get service {{ .Release.Name }}-console-svc -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'; echo ":{{ .Values.web.service.externalPort }}") | xargs open


### PR DESCRIPTION
## Description

- add a section on this in the README to clarify this, as well as a
  one-liner command to open the login screen directly when using the
  default values
  - also add a templated section in NOTES.txt to get the proper command
    when the values have been customized
    - NOTES.txt is a common place to add usage directions for charts,
      particularly since it can be templated
  - previously, neither the docs here nor in on the website said what to
    do once the Chart was installed, it just skipped straight to logging
    in, without saying how to access the login screen
    - I expressed confusion about this in a live call with Aqua
      Engineers, and there was some confusion about ports in general

  - also add a sentence on how one needs to add license key and admin
    user/pass
    - this caught me by surprise and the docs don't explicitly mention
      that this can be specified in the values with Secrets instead
      for an automated install

## Tags

Mentioned that admin user/pass values aren't well documented in #120 