### PR TITLE
Fix: user and password arguments for Scanner chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ $ helm upgrade --install --namespace aqua kube-enforcer ./kube-enforcer --set im
 ### Scanner chart (optional)
 
 ```bash
-$ helm upgrade --install --namespace aqua scanner ./scanner --set imageCredentials.username=<>,imageCredentials.password=<>,imageCredentials.email=<>
+$ helm upgrade --install --namespace aqua scanner ./scanner --set user=<>,password=<>
 ```
 
 # Troubleshooting

--- a/scanner/README.md
+++ b/scanner/README.md
@@ -33,7 +33,7 @@ cd aqua-helm/
 before installing scanner chart the recommandation is to create user with scanning permissions, [Link to documentations](https://docs.aquasec.com/docs/add-scanners#section-add-a-scanner-user)
 
 ```bash
-helm upgrade --install --namespace aqua scanner ./scanner --set imageCredentials.username=<>,imageCredentials.password=<>
+helm upgrade --install --namespace aqua scanner ./scanner --set user=<>,password=<>
 ```
 
 ## Configurable Variables

--- a/scanner/values.yaml
+++ b/scanner/values.yaml
@@ -14,6 +14,7 @@ image:
   tag: "5.0"
   pullPolicy: IfNotPresent
 
+# AquaCSP credentials to connect the scanner
 user:
 password:
 replicaCount: 1


### PR DESCRIPTION
### Description

The arguments for the scanner helm chart documented in the main Readme and in the Scanner chart are not valid and refer to image pull credentials that are not used in the scanner chart. The actual values are user and password used to connect the scanner to the aqua csp