### PR TITLE
Add documentation and default for web.service.externalPort value

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -125,6 +125,7 @@ Parameter | Description | Default
 `web.image.tag` | The image tag to use. | `5.0`
 `web.image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`
 `web.service.type` | k8s service type | `LoadBalancer`
+`web.service.externalPort` | k8s service type | `8080`
 `web.service.ports` | array of ports settings | `array`
 `web.replicaCount` | replica count | `1`
 `web.resources` |	Resource requests and limits | `{}`

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -146,6 +146,7 @@ web:
     pullPolicy: IfNotPresent
   service:
     type: LoadBalancer
+    externalPort: 8080
     ports:
       - name: aqua-web
         port: 8080


### PR DESCRIPTION
When enabling an Ingress, this field is required, but is not mentioned in either the documentation or the default `values.yaml` file.