### PR TITLE
Place components within Namespace

### DIFF
--- a/enforcer/templates/enforcer-daemonset.yaml
+++ b/enforcer/templates/enforcer-daemonset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ .Release.Name }}-ds
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-ds
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -24,6 +25,7 @@ spec:
       labels:
         app: {{ .Release.Name }}-ds
       name: {{ .Release.Name }}-ds
+      namespace: {{ .Release.Namespace }}
     spec:
       serviceAccount: {{ .Release.Name }}-sa
       hostPID: true

--- a/enforcer/templates/enforcer-token-secret.yaml
+++ b/enforcer/templates/enforcer-token-secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-token
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-token
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/enforcer/templates/image-pull-secret.yaml
+++ b/enforcer/templates/image-pull-secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-registry-secret
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/enforcer/templates/serviceaccount.yaml
+++ b/enforcer/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}-sa
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/db-deployment.yaml
+++ b/server/templates/db-deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-database
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-database
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -22,6 +23,7 @@ spec:
       labels:
         app: {{ .Release.Name }}-database
       name: {{ .Release.Name }}-database
+      namespace: {{ .Release.Namespace }}
     spec:
       serviceAccount: {{ .Release.Name }}-sa
       containers:

--- a/server/templates/db-password-secret.yaml
+++ b/server/templates/db-password-secret.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-database-password
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-database
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -29,6 +30,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-database-password
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-database
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/db-pvc.yaml
+++ b/server/templates/db-pvc.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-database-pvc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/db-service.yaml
+++ b/server/templates/db-service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-database-svc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-database
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/gate-deployment.yaml
+++ b/server/templates/gate-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-gateway
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-gateway
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -22,6 +23,7 @@ spec:
       labels:
         app: {{ .Release.Name }}-gateway
       name: {{ .Release.Name }}-gateway
+      namespace: {{ .Release.Namespace }}
     spec:
       serviceAccount: {{ .Release.Name }}-sa
       containers:

--- a/server/templates/gate-service.yaml
+++ b/server/templates/gate-service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-gateway-svc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-gateway
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/image-pull-secret.yaml
+++ b/server/templates/image-pull-secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-registry-secret
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/serviceaccount.yaml
+++ b/server/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}-sa
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/web-deployment.yaml
+++ b/server/templates/web-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-console
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-console
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -22,6 +23,7 @@ spec:
       labels:
         app: {{ .Release.Name }}-console
       name: {{ .Release.Name }}-console
+      namespace: {{ .Release.Namespace }}
     spec:
       serviceAccount: {{ .Release.Name }}-sa
       containers:

--- a/server/templates/web-ingress.yaml
+++ b/server/templates/web-ingress.yaml
@@ -10,6 +10,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-console-ingress
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-console-ingress
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/server/templates/web-secrets.yaml
+++ b/server/templates/web-secrets.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-console-secrets
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-console
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -11,6 +12,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 metadata:
   name: {{ .Release.Name }}-console-secrets
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
 {{- if .Values.admin.password }}

--- a/server/templates/web-service.yaml
+++ b/server/templates/web-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-console-svc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-console
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"


### PR DESCRIPTION
I'd like to be able to install server components into their own namespace.  However, currently, not all component manifests provide templating for setting the namespace.  This patch introduces that.

```
$ # on branch master
$ helm template  --namespace aqua aqua ./server -f /Users/jmales/Workspace/shipyard/aqua-demo/server/values.yaml > pre_stronger_ns.yaml
$ git checkout stronger_ns
Switched to branch 'stronger_ns'
$ helm template  --namespace aqua aqua ./server -f /Users/jmales/Workspace/shipyard/aqua-demo/server/values.yaml > post_stronger_ns.yaml
$ diff pre_stronger_ns.yaml post_stronger_ns.yaml 
31a32
>   namespace: aqua
44a46
>   namespace: aqua
58a61
>   namespace: aqua
65a69
>   namespace: aqua
118a123
>   namespace: aqua
142a148
>   namespace: aqua
166a173
>   namespace: aqua
182a190
>       namespace: aqua
238a247
>   namespace: aqua
254a264
>       namespace: aqua
314a325
>   namespace: aqua

```
