### PR TITLE
Invalid container name when using non-privileged

### DIFF
--- a/enforcer/templates/enforcer-daemonset.yaml
+++ b/enforcer/templates/enforcer-daemonset.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       annotations:
       {{- if not .Values.securityContext.privileged }}
-        container.apparmor.security.beta.kubernetes.io/aqua-agent: unconfined
+        container.apparmor.security.beta.kubernetes.io/enforcer: unconfined
       {{- end }}
       {{- if and (.Values.tolerations) (semverCompare "<1.6-0" .Capabilities.KubeVersion.GitVersion) }}
         scheduler.alpha.kubernetes.io/tolerations: '{{ toJson .Values.tolerations }}'


### PR DESCRIPTION
When the enforcer is set to use non-privileged mode by uncommenting the capabilities in values.yaml, line 18 becomes true, and the AppArmor annotation is added.  However the annotation was referring to "aqua-agent" instead of "enforcer", causing the deployment to fail.  (Invalid container name)