### PR TITLE
6.0 | New Create & Update verbs for Secret object

### DIFF
--- a/kube-enforcer/templates/cluster-role.yaml
+++ b/kube-enforcer/templates/cluster-role.yaml
@@ -4,5 +4,8 @@ metadata:
   name: {{ .Values.clusterRole.name }}
 rules:
   - apiGroups: ["*"]
-    resources: ["pods", "secrets", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "clusterroles", "clusterrolebindings", "componentstatuses"]
+    resources: ["pods", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "clusterroles", "clusterrolebindings", "componentstatuses"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "*" ]
+    resources: [ "secrets" ]
+    verbs: [ "get", "list", "watch", "update", "create" ]


### PR DESCRIPTION
To support auto-copy feature (secret will be copied from 'aqua' namespace to other namespaces),
Update & Create permession need for 'aqua-kube-enforcer-sa' ServiceAccount.