### PR TITLE
master | Remove 'UPDATE' operation from validation

### DIFF
--- a/kube-enforcer/templates/validating-webhook.yaml
+++ b/kube-enforcer/templates/validating-webhook.yaml
@@ -7,7 +7,7 @@ webhooks:
   - name: imageassurance.aquasec.com
     failurePolicy: {{ .Values.webhooks.failurePolicy }}  
     rules:
-      - operations: ["CREATE", "UPDATE"]
+      - operations: ["CREATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]


### PR DESCRIPTION
As the 'UPDATE' not necessary and creating un-usual duplicate logs,
removing it from validationwebhookconfig operations list.