### PR TITLE
Fix missing externalPort in web-ingress.yaml.  

### DIFF
--- a/server/templates/web-ingress.yaml
+++ b/server/templates/web-ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.web.ingress.enabled -}}
 {{- $fullname := .Release.Name -}}
-{{- $servicePort := .Values.web.service.externalPort -}}
+{{- $servicePort := (index .Values.web.service.ports 0).port -}}
 ---
 {{- if (semverCompare ">= 1.14" .Capabilities.KubeVersion.GitVersion) }}
 apiVersion: networking.k8s.io/v1beta1


### PR DESCRIPTION
web-ingress.yaml references "externalPort" in values.yaml which does not exist.  Since we are hard coding an http backend, we should point to the aqua-web port using http only.