### PR TITLE
ke_probe_5.0_SLK-29983

### DIFF
--- a/kube-enforcer/README.md
+++ b/kube-enforcer/README.md
@@ -22,6 +22,12 @@ These are Helm charts for installation and maintenance of Aqua Container Securit
 
 [Link](../docs/imagepullsecret.md)
 
+Note: Make sure you disable the imageCredentials creation from ```values.yaml``` If you are installing Kube Enforcer on the same Aqua cluster.
+
+```
+imageCredentials.create=false
+```
+
 ### Configure TLS Authentication between KubeEnforcer & API Server
 
 You need to enable TLS authentication from the API Server to the Kube-Enforcer. Perform these steps:

--- a/kube-enforcer/README.md
+++ b/kube-enforcer/README.md
@@ -22,7 +22,7 @@ These are Helm charts for installation and maintenance of Aqua Container Securit
 
 [Link](../docs/imagepullsecret.md)
 
-Note: Make sure you disable the imageCredentials creation from ```values.yaml``` If you are installing Kube Enforcer on the same Aqua cluster.
+Note: Make sure you disable the imageCredentials in ```values.yaml``` If you are installing Kube Enforcer on the same Aqua cluster.
 
 ```
 imageCredentials:

--- a/kube-enforcer/README.md
+++ b/kube-enforcer/README.md
@@ -25,7 +25,8 @@ These are Helm charts for installation and maintenance of Aqua Container Securit
 Note: Make sure you disable the imageCredentials creation from ```values.yaml``` If you are installing Kube Enforcer on the same Aqua cluster.
 
 ```
-imageCredentials.create=false
+imageCredentials:
+  create: false
 ```
 
 ### Configure TLS Authentication between KubeEnforcer & API Server

--- a/kube-enforcer/templates/kube-enforcer-deployment.yaml
+++ b/kube-enforcer/templates/kube-enforcer-deployment.yaml
@@ -20,6 +20,14 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 8443
+{{- with .Values.livenessProbe }}
+          livenessProbe:
+{{ toYaml . | indent 12 }}
+{{- end }}
+{{- with .Values.readinessProbe }}
+          readinessProbe:
+{{ toYaml . | indent 12 }}
+{{- end }}
           env:
             - name: AQUA_TOKEN
               valueFrom: 

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -2,7 +2,7 @@
 imageCredentials:
   # If aqua-registry already exists in the cluster. Make create to false. So it won't attempt to create a new registry secret. 
   create: true
-  name: aqua-ke-registry-secret # example
+  name: aqua-registry-secret # example
   repositoryUriPrefix: "registry.aquasec.com" # for dockerhub - "docker.io"
   registry: "registry.aquasec.com" #REQUIRED only if create is true, for dockerhub - "index.docker.io/v1/"
   username: ""

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -2,7 +2,7 @@
 imageCredentials:
   # If aqua-registry already exists in the cluster. Make create to false. So it won't attempt to create a new registry secret. 
   create: true
-  name: aqua-registry-secret # example
+  name: aqua-ke-registry-secret # example
   repositoryUriPrefix: "registry.aquasec.com" # for dockerhub - "docker.io"
   registry: "registry.aquasec.com" #REQUIRED only if create is true, for dockerhub - "index.docker.io/v1/"
   username: ""
@@ -51,3 +51,15 @@ validatingWebhook:
   name: kube-enforcer-admission-hook-config
   caBundle: ""
   failurePolicy: Ignore
+
+livenessProbe:
+  tcpSocket:
+    port: 8080
+  initialDelaySeconds: 60
+  periodSeconds: 30
+
+readinessProbe:
+  tcpSocket:
+    port: 8080
+  initialDelaySeconds: 60
+  periodSeconds: 30


### PR DESCRIPTION
Adding liveness and readiness probe for Kube-Enforcer for 5.0 branch chart and changing image registry secret name in values as it giving conflicts with secrets when trying to deploy on the same cluster where aqua got deployed.