### PR TITLE
support for advance ke | fixing lint issue | support for existing cert secrets in KE 

### DIFF
--- a/aqua-quickstart/Chart.yaml
+++ b/aqua-quickstart/Chart.yaml
@@ -20,4 +20,4 @@ version: 0.1.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 5.3
+appVersion: 6.0

--- a/enforcer/Chart.yaml
+++ b/enforcer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "5.3"
+appVersion: "6.0"
 description: A Helm chart for the Aqua Enforcer
 name: enforcer
-version: 5.3.0
+version: 6.0.0

--- a/gateway/Chart.yaml
+++ b/gateway/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "5.3"
+appVersion: "6.0"
 description: A Helm chart for the Aqua Gateway
 name: gateway
-version: 5.3.0
+version: 6.0.0

--- a/kube-enforcer/Chart.yaml
+++ b/kube-enforcer/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "6.0"
 description: A Helm chart for the Aqua KubeEnforcer
 name: kube-enforcer
-version: 0.1.0
+version: 6.0.0
 icon: https://avatars3.githubusercontent.com/u/12783832?s=200&v=4
 keywords:
 - scanning

--- a/kube-enforcer/README.md
+++ b/kube-enforcer/README.md
@@ -129,6 +129,10 @@ To perform kube-bench scans in the cluster, the KubeEnforcer needs:
 | `certsSecret.serverKey`           | Certificate key for TLS authentication with the Kubernetes api-server       | `N/A`                   | `YES`                   |
 | `webhooks.caBundle`               | Root certificate for TLS authentication with the Kubernetes api-server      | `N/A`                   | `YES`                   |
 | `envs.gatewayAddress`             | Gateway host address                                                        | `aqua-gateway-svc:8443` | `YES`                   |
+| `kubeEnforcerAdvance.enable`      | Advance Kube Enforcer Deployment                                            | `false`                 | `NO`                    |
+| `kubeEnforcerAdvance.envoy.certsSecret.name`  | Envoy TLS certs secret for advance KE deployment                | `N/A`                   | `NO`                    |
+| `existing_secret.enable`          | To use existing secret for KE certs                                         | `false`                 | `NO`                    |
+| `existing_secret.secretName`      | existing secret name for KE certs                                           | `N/A`                   | `NO`                    |
 
 ## Issues and feedback
 

--- a/kube-enforcer/templates/_helpers.tpl
+++ b/kube-enforcer/templates/_helpers.tpl
@@ -32,17 +32,21 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{- define "imagePullSecret" }}
-{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" (required "A valid .Values.imageCredentials.registry entry required!" .Values.imageCredentials.registry) (printf "%s:%s" (required "A valid .Values.imageCredentials.username entry required!" .Values.imageCredentials.username) (required "A valid .Values.imageCredentials.password entry required!" .Values.imageCredentials.password) | b64enc) | b64enc }}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" (required "A valid .Values.imageCredentials.registry entry required" .Values.imageCredentials.registry) (printf "%s:%s" (required "A valid .Values.imageCredentials.username entry required" .Values.imageCredentials.username) (required "A valid .Values.imageCredentials.password entry required" .Values.imageCredentials.password) | b64enc) | b64enc }}
 {{- end }}
 
 {{- define "serverCertificate" }}
-{{- printf "%s" (required "A valid .Values.certsSecret.serverCertificate entry required!" .Values.certsSecret.serverCertificate) | replace "\n" "" }}
+{{- printf "%s" (required "A valid .Values.certsSecret.serverCertificate entry required" .Values.certsSecret.serverCertificate) | replace "\n" "" }}
 {{- end }}
 
 {{- define "serverKey" }}
-{{- printf "%s" (required "A valid .Values.certsSecret.serverKey entry required!" .Values.certsSecret.serverKey) | replace "\n" "" }}
+{{- printf "%s" (required "A valid .Values.certsSecret.serverKey entry required" .Values.certsSecret.serverKey) | replace "\n" "" }}
 {{- end }}
 
 {{- define "caBundle" }}
-{{- printf "%s" (required "A valid .Values.webhooks.caBundle entry required!" .Values.webhooks.caBundle) | replace "\n" "" }}
+{{- printf "%s" (required "A valid .Values.webhooks.caBundle entry required" .Values.webhooks.caBundle) | replace "\n" "" }}
+{{- end }}
+
+{{- define "existing_secret" }}
+{{- printf "%s" (required "A valid .Values.existing_secret.secretName required" .Values.existing_secret.secretName ) }}
 {{- end }}

--- a/kube-enforcer/templates/envoy-config.yaml
+++ b/kube-enforcer/templates/envoy-config.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.kubeEnforcerAdvance.enable -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-envoy-conf
+  labels:
+    app: {{ .Release.Name }}-envoy
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+{{- range $key, $value := .Values.kubeEnforcerAdvance.envoy.files }}
+  {{ $key }}: |-
+{{ $valueWithDefault := default "" $value -}}
+{{ tpl $valueWithDefault $ | indent 4 }}
+{{- end -}}
+{{- end -}}

--- a/kube-enforcer/templates/kube-enforcer-certs.yaml
+++ b/kube-enforcer/templates/kube-enforcer-certs.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existing_secret.enable }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,3 +7,6 @@ metadata:
 data:
   server.crt: {{ template "serverCertificate" . }}  # place server cert
   server.key: {{ template "serverKey" . }}  # place server key
+{{- else if not .Values.existing_secret.secretName }}
+{{ template "existing_secret" . }}
+{{- end }}

--- a/kube-enforcer/templates/kube-enforcer-deployment.yaml
+++ b/kube-enforcer/templates/kube-enforcer-deployment.yaml
@@ -19,7 +19,13 @@ spec:
           image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: Always
           ports:
+{{- if not .Values.kubeEnforcerAdvance.enable }}
             - containerPort: 8443
+{{- else }}
+            - containerPort: 8449
+            - containerPort: 8442
+{{- end }}
+{{- if not .Values.kubeEnforcerAdvance.enable }}
 {{- with .Values.livenessProbe }}
           livenessProbe:
 {{ toYaml . | indent 12 }}
@@ -27,6 +33,7 @@ spec:
 {{- with .Values.readinessProbe }}
           readinessProbe:
 {{ toYaml . | indent 12 }}
+{{- end }}
 {{- end }}
 {{- with .Values.resources }}
           resources:
@@ -37,7 +44,9 @@ spec:
               valueFrom: 
                 secretKeyRef:
                   name: {{ .Values.aquaSecret.name }}
-                  key: token      
+                  key: token
+            # Specify whether to enable/disable the cache by using "yes", "true", "no", "false" values.
+            # Default value is "yes".
             - name: AQUA_ENABLE_CACHE
               value: "{{ .Values.aqua_enable_cache }}"
             - name: AQUA_CACHE_EXPIRATION_PERIOD
@@ -48,19 +57,79 @@ spec:
               value: /certs/server.key
             - name: AQUA_GATEWAY_SECURE_ADDRESS
               value: {{ .Values.envs.gatewayAddress }}
+{{- if .Values.kubeEnforcerAdvance.enable }}
+            - name: AQUA_TLS_PORT
+              value: "8449"
+            - name: AQUA_KE_SERVER_PORT
+              value: "8442"
+{{- else }}
             - name: AQUA_TLS_PORT
               value: "8443"
+{{- end }}
+            - name: CLUSTER_NAME
+              value: "aqua-secure"   # Cluster display name in aqua enterprise.
             - name: SCALOCK_LOG_LEVEL
               value: {{ .Values.logLevel | default "INFO" }}
+{{- if .Values.kubeEnforcerAdvance.enable }}
+            - name: AQUA_ENVOY_MODE
+              value: "true"
+{{- end }}
           volumeMounts:
-            - name: "certs"
+            - name: "ke-certs"
               mountPath: "/certs"
+{{- if .Values.kubeEnforcerAdvance.enable }}
+            - name: "envoy-shared"
+              mountPath: "/etc/aquasec/envoy"
+{{- end }}
+{{- if .Values.kubeEnforcerAdvance.enable }}
+        - name: envoy
+          image: "{{ .Values.kubeEnforcerAdvance.envoy.image.repository }}:{{ .Values.kubeEnforcerAdvance.envoy.image.tag }}"
+          imagePullPolicy: "{{ .Values.kubeEnforcerAdvance.envoy.image.pullPolicy }}"
+          command: ["/bin/sh", "-c", "cp /etc/envoy/cds.yaml /etc/aquasec/envoy/cds.yaml && touch /etc/aquasec/envoy/ca-certificates.crt && envoy -c /etc/envoy/envoy.yaml"]
+          ports:
+          - containerPort: 8443
+            protocol: TCP
+          volumeMounts:
+          - mountPath: /etc/envoy
+            name: envoy-config
+          - name: "envoy-shared"
+            mountPath: "/etc/aquasec/envoy"
+          {{ if .Values.kubeEnforcerAdvance.envoy.certsSecret.name }}
+          - mountPath: /etc/ssl/envoy
+            name: envoy-certs
+          {{- end }}
+{{- with .Values.kubeEnforcerAdvance.envoy.livenessProbe }}
+          livenessProbe:
+{{ toYaml . | indent 12 }}
+{{- end }}
+{{- with .Values.kubeEnforcerAdvance.envoy.readinessProbe }}
+          readinessProbe:
+{{ toYaml . | indent 12 }}
+{{- end }}
+{{- end }}
       volumes:
-        - name: "certs"
+        - name: "ke-certs"
           secret:
+{{- if .Values.existing_secret.enable }}
+            secretName: {{ .Values.existing_secret.secretName }}
+{{- else }}
             secretName: {{ .Values.certsSecret.name }}
+{{- end }}
+{{- if .Values.kubeEnforcerAdvance.enable }}
+        - name: "envoy-config"
+          configMap:
+            name: "{{ .Release.Name }}-envoy-conf"
+        - name: "envoy-shared"
+          emptyDir: {}
+        {{ if .Values.kubeEnforcerAdvance.envoy.certsSecret.name }}
+        - name: envoy-certs
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.kubeEnforcerAdvance.envoy.certsSecret.name }}
+        {{- end }}
+{{- end }}
       imagePullSecrets:
         - name: {{ .Values.imageCredentials.name }}
   selector:
     matchLabels:
-      app: {{ include "kube-enforcer.fullname" . }}                           
+      app: {{ include "kube-enforcer.fullname" . }}

--- a/kube-enforcer/templates/kube-enforcer-token.yaml
+++ b/kube-enforcer/templates/kube-enforcer-token.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: {{ .Values.namespace }}
 type: Opaque
 data:
-  token:    {{ .Values.aquaSecret.kubeEnforcerToken | b64enc | quote }}               # aqua kube enforcer token
+  token: {{ .Values.aquaSecret.kubeEnforcerToken | b64enc }}               # aqua kube enforcer token

--- a/kube-enforcer/templates/service.yaml
+++ b/kube-enforcer/templates/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,5 +10,8 @@ spec:
   ports:
     - port: 443
       targetPort: 8443
+{{- if .Values.kubeEnforcerAdvance.enable }}
+      name: envoy
+{{- end }}
   selector:
     app: {{ include "kube-enforcer.fullname" . }}

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -27,6 +27,11 @@ namespace: "aqua"
 
 logLevel:
 
+#enable to true if you want to use existing secret for the cluster
+existing_secret:
+  enable: false
+  secretName:
+
 certsSecret:
   name: aqua-kube-enforcer-certs
   serverCertificate: ""
@@ -34,7 +39,8 @@ certsSecret:
 
 aquaSecret:
   name: aqua-kube-enforcer-token
-  kubeEnforcerToken: ""
+# Enter the enforcer token in "clear-text" formate without quotes generated from the Console UI
+  kubeEnforcerToken:
 
 envs:
   gatewayAddress: aqua-gateway-svc.aqua:8443 
@@ -83,3 +89,199 @@ resources: {}
   # limits:
   #   cpu: 500m
   #   memory: 1.5Gi
+
+
+##Kube Enforcer advance deployment options
+kubeEnforcerAdvance:
+  enable: false
+
+  envoy:
+    image:
+      repository: envoyproxy/envoy-alpine
+      tag: v1.15.1
+      pullPolicy: IfNotPresent
+
+    certsSecret:
+      name:
+##Accepted file names for certificates are tls.crt , tls.key
+
+    readinessProbe:
+      exec:
+        command:
+        - cat
+        - /etc/aquasec/envoy/configured
+      initialDelaySeconds: 30
+      periodSeconds: 10
+
+    livenessProbe: {}
+    resources: {}
+
+    files:
+      envoy.yaml: |-
+        node:
+          cluster: k8s
+          id: <INSERT NODE ID>
+
+        dynamic_resources:
+          cds_config:
+            path: /etc/aquasec/envoy/cds.yaml
+            initial_fetch_timeout: 0s
+          lds_config:
+            path: /etc/envoy/lds.yaml
+      lds.yaml: |-
+        resources:
+          - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+            name: listener_0
+            address:
+              socket_address:
+                address: 0.0.0.0
+                port_value: 8443
+            filter_chains:
+              - filters:
+                  - name: envoy.filters.network.http_connection_manager
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                      stream_idle_timeout: 0s
+                      drain_timeout: 20s
+                      access_log:
+                        - name: envoy.access_loggers.file
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                            path: "/dev/stdout"
+                      codec_type: AUTO
+                      stat_prefix: ingress_https
+                      route_config:
+                        name: local_route
+                        virtual_hosts:
+                          - name: https
+                            domains:
+                              - "*"
+                            routes:
+                              - match:
+                                  prefix: "/agent_grpc_channel.GWChannelV2/PushNotificationHandler"
+                                  grpc: { }
+                                route:
+                                  cluster: aqua-kube-enforcer
+                                  timeout: 0s
+                              - match:
+                                  prefix: "/"
+                                  grpc: { }
+                                route:
+                                  cluster: aqua-gateway
+                                  timeout: 0s
+                              - match:
+                                  prefix: "/"
+                                route:
+                                  cluster: aqua-kube-enforcer-k8s
+                                  timeout: 0s
+
+                      http_filters:
+                        - name: envoy.filters.http.health_check
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.config.filter.http.health_check.v2.HealthCheck
+                            pass_through_mode: false
+                            headers:
+                              - name: ":path"
+                                exact_match: "/healthz"
+                              - name: "x-envoy-livenessprobe"
+                                exact_match: "healthz"
+                        - name: envoy.filters.http.router
+                          typed_config: { }
+                transport_socket:
+                  name: envoy.transport_sockets.tls
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+                    common_tls_context:
+                      alpn_protocols: "h2,http/1.1"
+                      tls_certificates:
+                        - certificate_chain:
+                            filename: "/etc/ssl/envoy/tls.crt"
+                          private_key:
+                            filename: "/etc/ssl/envoy/tls.key"
+      cds.yaml: |-
+        resources:
+        - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+          name: aqua-kube-enforcer
+          connect_timeout: 180s
+          type: STRICT_DNS
+          dns_lookup_family: V4_ONLY
+          lb_policy: ROUND_ROBIN
+          http2_protocol_options:
+            hpack_table_size: 4294967
+            max_concurrent_streams: 2147483647
+          circuit_breakers:
+            thresholds:
+              max_pending_requests: 2147483647
+              max_requests: 2147483647
+          load_assignment:
+            cluster_name: aqua-kube-enforcer
+            endpoints:
+              - lb_endpoints:
+                - endpoint:
+                    address:
+                      socket_address:
+                        address: localhost
+                        port_value: 8442
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              sni: aqua-kube-enforcer
+        - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+          name: aqua-kube-enforcer-k8s
+          connect_timeout: 180s
+          type: STRICT_DNS
+          dns_lookup_family: V4_ONLY
+          lb_policy: ROUND_ROBIN
+          circuit_breakers:
+            thresholds:
+              max_pending_requests: 2147483647
+              max_requests: 2147483647
+          load_assignment:
+            cluster_name: aqua-kube-enforcer-k8s
+            endpoints:
+              - lb_endpoints:
+                - endpoint:
+                    address:
+                      socket_address:
+                        address: localhost
+                        port_value: 8449
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              sni: aqua-kube-enforcer-k8s
+        - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+          name: aqua-gateway
+          connect_timeout: 180s
+          type: STRICT_DNS
+          dns_lookup_family: V4_ONLY
+          lb_policy: ROUND_ROBIN
+          http2_protocol_options:
+            hpack_table_size: 4294967
+            max_concurrent_streams: 2147483647
+          circuit_breakers:
+            thresholds:
+              max_pending_requests: 2147483647
+              max_requests: 2147483647
+          load_assignment:
+            cluster_name: aqua-gateway
+            endpoints:
+              - lb_endpoints:
+                - endpoint:
+                    address:
+                      socket_address:
+                        address: aqua-gateway.aqua
+                        port_value: 8443
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              sni: aqua-gateway
+      validation_context_sds_secret.yaml: |-
+        resources:
+          - "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"
+            name: "validation_context_sds"
+            validation_context:
+              trusted_ca:
+                filename: /etc/aquasec/envoy/ca-certificates.crt

--- a/server/Chart.yaml
+++ b/server/Chart.yaml
@@ -1,5 +1,7 @@
 apiVersion: v1
-appVersion: "5.3"
+appVersion: "6.0"
 description: A Helm chart for the Aqua Console components
 name: server
-version: 5.3.0
+version: 6.0.0
+icon: https://avatars3.githubusercontent.com/u/12783832?s=200&v=4
+

--- a/server/README.md
+++ b/server/README.md
@@ -155,7 +155,7 @@ Parameter | Description | Default| Mandatory
 `imageCredentials.username` | Your Docker registry (DockerHub, etc.) username | `aqua-registry-secret`| `YES` 
 `imageCredentials.password` | Your Docker registry (DockerHub, etc.) password | `unset`| `YES` 
 `platform` | Orchestration platform name (Allowed values are aks, eks, gke, openshift) | `unset` | `YES`
-`openshift_route.enabled` | to create openshift routes for web and gateway | `false` | `NO`
+`openshift_route.create` | to create openshift routes for web and gateway | `false` | `NO`
 `rbac.enabled` | if to create rbac configuration for aqua | `true`| `YES` 
 `rbac.privileged` | determines if any container in a pod can enable privileged mode. | `true`| `NO` 
 `rbac.roleRef` | name of rbac role to set in not create by helm | `unset`| `NO` 

--- a/server/templates/_helpers.tpl
+++ b/server/templates/_helpers.tpl
@@ -16,7 +16,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "imagePullSecret" }}
-{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" (required "A valid .Values.imageCredentials.registry entry required!" .Values.imageCredentials.registry) (printf "%s:%s" (required "A valid .Values.imageCredentials.username entry required!" .Values.imageCredentials.username) (required "A valid .Values.imageCredentials.password entry required!" .Values.imageCredentials.password) | b64enc) | b64enc }}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" (required "A valid .Values.imageCredentials.registry entry required" .Values.imageCredentials.registry) (printf "%s:%s" (required "A valid .Values.imageCredentials.username entry required" .Values.imageCredentials.username) (required "A valid .Values.imageCredentials.password entry required" .Values.imageCredentials.password) | b64enc) | b64enc }}
+{{- end }}
+
+{{- define "platform" }}
+{{- printf "%s" (required "A valid .Values.platform entry required" .Values.platform ) | replace "\n" "" }}
 {{- end }}
 
 {{/*
@@ -39,9 +43,9 @@ Inject extra environment populated by secrets, if populated
 {{- range .extraSecretEnvironmentVars }}
 - name: {{ .envName }}
   valueFrom:
-   secretKeyRef:
-     name: {{ .secretName }}
-     key: {{ .secretKey }}
+    secretKeyRef:
+      name: {{ .secretName }}
+      key: {{ .secretKey }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/server/templates/openshift-route.yaml
+++ b/server/templates/openshift-route.yaml
@@ -1,5 +1,6 @@
-{{- if eq .Values.platform "openshift" }}
-{{- if .Values.openshift_route.enabled }}
+{{- if not .Values.platform -}}
+{{ template "platform" . }}
+{{- else if and ( .Values.openshift_route.create ) (eq .Values.platform "openshift" ) }}
 ---
 ##webroute
 apiVersion: route.openshift.io/v1
@@ -40,5 +41,4 @@ spec:
     termination: passthrough
     insecureEdgeTerminationPolicy: None
   wildcardPolicy: None
-{{- end }}
 {{- end }}

--- a/server/templates/rbac.yaml
+++ b/server/templates/rbac.yaml
@@ -70,8 +70,10 @@ roleRef:
   {{- else }}
   name: {{ .Release.Name }}-cluster-role
   {{- end }}
-{{- if .Values.platform }}
-  {{- if eq .Values.platform "openshift" }}
+
+{{- if not .Values.platform -}}
+{{ template "platform" .}}
+{{- else if eq .Values.platform "openshift" }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -138,6 +140,6 @@ volumes:
 - projected
 - secret
 - hostPath
-  {{- end }}
-{{- end }}
+{{- end -}}
+
 {{- end }}

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -12,10 +12,11 @@ rbac:
   privileged: true
   roleRef:
 
-platform:           #Please specify k8s platform acronym. Allowed values are aks, eks, gke, openshift
+#Please specify k8s platform acronym. Allowed values are aks, eks, gke, openshift
+platform:
 
 openshift_route:
-  enabled: false    #Enable if required openshift route for web and gateway
+  create: false    #Enable if required openshift route for web and gateway
 
 # enable only one of the modes
 clustermode: 


### PR DESCRIPTION
1. Adding support for KE advance deployment
2. Adding support to use server.key, server.crt from existing secrets in kube-enforcer charts
3. fixing lint issue in server chart around passing empty platform
4. updated the chart versions
