### PR TITLE
fixes #204

### DIFF
--- a/enforcer/templates/enforcer-daemonset.yaml
+++ b/enforcer/templates/enforcer-daemonset.yaml
@@ -25,7 +25,9 @@ spec:
         app: {{ .Release.Name }}-ds
       name: {{ .Release.Name }}-ds
     spec:
+    {{- if .Values.multi_cluster }}
       serviceAccount: {{ .Release.Namespace }}-sa
+    {{- end }}
       hostPID: true
       containers:
       - name: enforcer


### PR DESCRIPTION
When multi_cluster is false, the ServiceAccount is not created, in which case it should not be referenced here