### PR TITLE
5.3 | adding imagecreds for scanner

### DIFF
--- a/scanner/templates/_helpers.tpl
+++ b/scanner/templates/_helpers.tpl
@@ -51,9 +51,13 @@ Inject extra environment populated by secrets, if populated
 {{- range .extraSecretEnvironmentVars }}
 - name: {{ .envName }}
   valueFrom:
-   secretKeyRef:
-     name: {{ .secretName }}
-     key: {{ .secretKey }}
+    secretKeyRef:
+      name: {{ .secretName }}
+      key: {{ .secretKey }}
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "imagePullSecret" }}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" (required "A valid .Values.imageCredentials.registry entry required" .Values.imageCredentials.registry) (printf "%s:%s" (required "A valid .Values.imageCredentials.username entry required" .Values.imageCredentials.username) (required "A valid .Values.imageCredentials.password entry required" .Values.imageCredentials.password) | b64enc) | b64enc }}
+{{- end }}

--- a/scanner/templates/image-pull-secret.yaml
+++ b/scanner/templates/image-pull-secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.imageCredentials.create -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-registry-secret
+  labels:
+    app: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "imagePullSecret" . }}
+{{- end -}}

--- a/scanner/templates/scanner-deployment.yaml
+++ b/scanner/templates/scanner-deployment.yaml
@@ -27,14 +27,18 @@ spec:
       securityContext:
 {{ toYaml . | indent 8 }}
       {{- end }}
+      {{- if .Values.aquaCluster}}
       serviceAccount: {{ .Values.serviceAccount }}
+      {{- else }}
+      serviceAccount: {{ .Release.Namespace }}-sa
+      {{- end }}
       containers:
       - name: scanner
         {{- with .Values.container_securityContext }}
         securityContext:
 {{ toYaml . | indent 10 }}
         {{- end }}
-        image: "{{ .Values.repositoryUriPrefix }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         args:
         - daemon
@@ -89,4 +93,8 @@ spec:
       - name: docker-socket-mount
         hostPath:
           path: {{ .Values.dockerSock.path }}
+      {{- end }}
+      {{- if not .Values.aquaCluster }}
+      imagePullSecrets:
+        - name: {{ .Values.imageCredentials.name }}
       {{- end }}

--- a/scanner/templates/service-account.yaml
+++ b/scanner/templates/service-account.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.aquaCluster }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Namespace }}-sa
+  labels:
+    app: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/scanner/values.yaml
+++ b/scanner/values.yaml
@@ -1,10 +1,20 @@
-repositoryUriPrefix: "registry.aquasec.com" # for dockerhub - "docker.io"
+# Specifies the secret data for imagePullSecrets needed to fetch the private docker images
+imageCredentials:
+  create: false   #enable to create registry credentials for scanner image
+  name: scanner-registry-secret # example
+  repositoryUriPrefix: "registry.aquasec.com" # for dockerhub - "docker.io"
+  registry: "registry.aquasec.com" #REQUIRED only if create is true, for dockerhub - "index.docker.io/v1/"
+  username: ""
+  password: ""
+
+aquaCluster: true   #Change it to false if deploying scanner on a different cluster(Not in Aqua deployed cluster)
 
 dockerSock:
   mount: # put true for mount docker socket.
   path: /var/run/docker.sock # pks - /var/vcap/data/sys/run/docker/docker.sock
 
 serviceAccount: "aqua-sa"
+
 server:
   serviceName: "aqua-console-svc" # example
   port: 8080
@@ -16,8 +26,8 @@ image:
 
 logLevel:
 
-user:
-password:
+user: ""
+password: ""
 replicaCount: 1
 livenessProbe: {}
 readinessProbe: {}


### PR DESCRIPTION
By Changing flags form values.yaml can deploy the scanner on a different cluster other than the Aqua console, without creating registry creds for the scanner image.