### PR TITLE
issue with registry secret name created/referenced

### DIFF
--- a/server/templates/image-pull-secret.yaml
+++ b/server/templates/image-pull-secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-registry-secret
+  name: {{ .Release.Namespace }}-registry-secret
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"


### PR DESCRIPTION
fixing an issue between secret name created and secret name referenced for the image registry. Below are the reference material for the change required to correct the server deployment and consistency with the enforcer image-pull-secret.

https://github.com/aquasecurity/aqua-helm/blob/5.3/server/templates/serviceaccount.yaml
imagePullSecrets:
{{- if .Values.imageCredentials.create }}
- name: {{ .Release.Namespace }}-registry-secret
{{- else }}

https://github.com/aquasecurity/aqua-helm/blob/5.3/enforcer/templates/image-pull-secret.yaml
  name: {{ .Release.Namespace }}-registry-secret