### PR TITLE
5.3 | updating quick-start yamls

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Use the [**aqua-quickstart**](aqua-quickstart) chart to
 
   3. Deploy aqua-quickstart chart
   ```bash
-  $ helm upgrade --install --namespace aqua aqua ./aqua-quickstart --set imageCredentials.username=<>,imageCredentials.password=<>
+  $ helm upgrade --install --namespace aqua aqua ./aqua-quickstart --set imageCredentials.username=<>,imageCredentials.password=<>,platform=<>
   ```
 
 # Issues and feedback

--- a/aqua-quickstart/Chart.yaml
+++ b/aqua-quickstart/Chart.yaml
@@ -16,8 +16,10 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.1.0
+icon: https://avatars3.githubusercontent.com/u/12783832?s=200&v=4
+
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 5.3
+appVersion: "5.3"

--- a/aqua-quickstart/templates/_helpers.tpl
+++ b/aqua-quickstart/templates/_helpers.tpl
@@ -19,6 +19,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" (required "A valid .Values.imageCredentials.registry entry required" .Values.imageCredentials.registry) (printf "%s:%s" (required "A valid .Values.imageCredentials.username entry required" .Values.imageCredentials.username) (required "A valid .Values.imageCredentials.password entry required" .Values.imageCredentials.password) | b64enc) | b64enc }}
 {{- end }}
 
+{{- define "platform" }}
+{{- printf "%s" (required "A valid .Values.platform entry required" .Values.platform ) | replace "\n" "" }}
+{{- end }}
+
 {{/*
 Inject extra environment vars in the format key:value, if populated
 */}}

--- a/aqua-quickstart/templates/db-deployment.yaml
+++ b/aqua-quickstart/templates/db-deployment.yaml
@@ -23,20 +23,49 @@ spec:
         app: {{ .Release.Name }}-database
       name: {{ .Release.Name }}-database
     spec:
+      {{- with .Values.db.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       serviceAccount: {{ .Release.Namespace }}-sa
-      containers:
-      - name: db
-        securityContext:
-          {{- toYaml .Values.db.securityContext | nindent 12 }}
-        image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.db.image.repository }}:{{ .Values.db.image.tag }}"
-        imagePullPolicy: "{{ .Values.db.image.pullPolicy }}"
+      initContainers:
+      - name: {{ .Release.Name }}-db-init
         env:
-        {{- if .Values.db.passwordSecret }}
+        {{- if .Values.db.passwordFromSecret.enabled }}
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.db.dbPasswordName }}
-              key: {{ .Values.db.dbPasswordKey }}
+              name: {{ .Values.db.passwordFromSecret.dbPasswordName }}
+              key: {{ .Values.db.passwordFromSecret.dbPasswordKey }}
+        {{- else }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-database-password
+              key: db-password
+        {{- end }}
+        - name: PGDATA
+          value: "/var/lib/postgresql/data/db-files"
+        image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.db.image.repository }}:{{ .Values.db.image.tag }}"
+        command: [ "sh", "-c", "[ -f $PGDATA/server.key ] && chmod 600 $PGDATA/server.key || echo 'OK' " ]
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: postgres-database
+      containers:
+      - name: db
+        {{- with .Values.db.container_securityContext }}
+        securityContext:
+{{ toYaml . | indent 10 }}
+        {{- end }}
+        image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.db.image.repository }}:{{ .Values.db.image.tag }}"
+        imagePullPolicy: "{{ .Values.db.image.pullPolicy }}"
+        env:
+        {{- if .Values.db.passwordFromSecret.enabled }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.db.passwordFromSecret.dbPasswordName }}
+              key: {{ .Values.db.passwordFromSecret.dbPasswordKey }}
         {{- else }}
         - name: POSTGRES_PASSWORD
           valueFrom:
@@ -106,20 +135,49 @@ spec:
         app: {{ .Release.Name }}-audit-database
       name: {{ .Release.Name }}-audit-database
     spec:
+      {{- with .Values.db.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       serviceAccount: {{ .Release.Namespace }}-sa
-      containers:
-      - name: auditdb
-        securityContext:
-          {{- toYaml .Values.db.securityContext | nindent 12 }}
-        image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.db.image.repository }}:{{ .Values.db.image.tag }}"
-        imagePullPolicy: "{{ .Values.db.image.pullPolicy }}"
+      initContainers:
+      - name: {{ .Release.Name }}-auditdb-init
         env:
-        {{- if .Values.db.passwordSecret }}
+        {{- if .Values.db.passwordFromSecret.enabled }}
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.db.dbPasswordName }}
-              key: {{ .Values.db.dbPasswordKey }}
+              name: {{ .Values.db.passwordFromSecret.dbAuditPasswordName }}
+              key: {{ .Values.db.passwordFromSecret.dbAuditPasswordKey }}
+        {{- else }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-database-password
+              key: audit-password
+        {{- end }}
+        - name: PGDATA
+          value: "/var/lib/postgresql/data/db-files"
+        image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.db.image.repository }}:{{ .Values.db.image.tag }}"
+        command: [ "sh", "-c", "[ -f $PGDATA/server.key ] && chmod 600 $PGDATA/server.key || echo 'OK' " ]
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: postgres-audit-database
+      containers:
+      - name: auditdb
+        {{- with .Values.db.container_securityContext }}
+        securityContext:
+{{ toYaml . | indent 10 }}
+        {{- end }}
+        image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.db.image.repository }}:{{ .Values.db.image.tag }}"
+        imagePullPolicy: "{{ .Values.db.image.pullPolicy }}"
+        env:
+        {{- if .Values.db.passwordFromSecret.enabled }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.db.passwordFromSecret.dbAuditPasswordName }}
+              key: {{ .Values.db.passwordFromSecret.dbAuditPasswordKey }}
         {{- else }}
         - name: POSTGRES_PASSWORD
           valueFrom:

--- a/aqua-quickstart/templates/db-password-secret.yaml
+++ b/aqua-quickstart/templates/db-password-secret.yaml
@@ -1,5 +1,5 @@
 
-{{- if not .Values.db.passwordSecret }}
+{{- if not .Values.db.passwordFromSecret.enabled }}
 {{- if .Values.db.external.enabled }}
 ---
 apiVersion: v1

--- a/aqua-quickstart/templates/envoy-config.yaml
+++ b/aqua-quickstart/templates/envoy-config.yaml
@@ -11,6 +11,7 @@ metadata:
 data:
 {{- range $key, $value := .Values.envoy.files }}
   {{ $key }}: |-
-{{ $value | default "" | indent 4 }}
+{{ $valueWithDefault := default "" $value -}}
+{{ tpl $valueWithDefault $ | indent 4 }}
 {{- end -}}
 {{- end }}

--- a/aqua-quickstart/templates/envoy-deployment.yaml
+++ b/aqua-quickstart/templates/envoy-deployment.yaml
@@ -30,12 +30,12 @@ spec:
       - image: "{{ .Values.envoy.image.repository }}:{{ .Values.envoy.image.tag }}"
         imagePullPolicy: "{{ .Values.envoy.image.pullPolicy }}"
         name: envoy
+        env:
+        - name: ENVOY_UID
+          value: "0"
         ports:
         - containerPort: 8443
           name: https
-          protocol: TCP
-        - containerPort: 8082
-          name: healthserver
           protocol: TCP
         volumeMounts:
         - mountPath: /etc/envoy

--- a/aqua-quickstart/templates/gate-deployment.yaml
+++ b/aqua-quickstart/templates/gate-deployment.yaml
@@ -22,11 +22,17 @@ spec:
         app: {{ .Release.Name }}-gateway
       name: {{ .Release.Name }}-gateway
     spec:
+      {{- with .Values.gate.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       serviceAccount: {{ .Release.Namespace }}-sa
       containers:
       - name: gate
+        {{- with .Values.gate.container_securityContext }}
         securityContext:
-          {{- toYaml .Values.gate.securityContext | nindent 12 }}
+{{ toYaml . | indent 10 }}
+        {{- end }}
         image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.gate.image.repository }}:{{ .Values.gate.image.tag }}"
         imagePullPolicy: "{{ .Values.gate.image.pullPolicy }}"
         env:
@@ -40,12 +46,12 @@ spec:
           value: "0.0.0.0:8082"
         - name: SCALOCK_DBUSER
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.user "postgres" }}
-        {{- if .Values.db.passwordSecret }}
+        {{- if .Values.db.passwordFromSecret.enabled }}
         - name: SCALOCK_DBPASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.db.dbPasswordName }}
-              key: {{ .Values.db.dbPasswordKey }}
+              name: {{ .Values.db.passwordFromSecret.dbPasswordName }}
+              key: {{ .Values.db.passwordFromSecret.dbPasswordKey }}
           {{- else }}
         - name: SCALOCK_DBPASSWORD
           valueFrom:
@@ -65,14 +71,13 @@ spec:
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.port "5432" | quote }}
         - name: SCALOCK_AUDIT_DBUSER
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.auditUser "postgres" }}
-          {{- if .Values.db.passwordSecret }}
         - name: SCALOCK_AUDIT_DBPASSWORD
+          {{- if .Values.db.passwordFromSecret.enabled }}
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.db.dbAuditPasswordName }}
-              key: {{ .Values.db.dbAuditPasswordKey }}
-          {{- else }}
-        - name: SCALOCK_AUDIT_DBPASSWORD
+              name: {{ .Values.db.passwordFromSecret.dbAuditPasswordName }}
+              key: {{ .Values.db.passwordFromSecret.dbAuditPasswordKey }}
+          {{- else if and ( not .Values.db.passwordFromSecret.enabled ) ( .Values.db.external.enabled ) }}
           valueFrom:
             secretKeyRef:
               name: {{ .Release.Name }}-database-password
@@ -81,6 +86,11 @@ spec:
               {{- else }}
               key: db-password
               {{- end }}
+          {{- else }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-database-password
+              key: audit-password
           {{- end }}
         - name: SCALOCK_AUDIT_DBNAME
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.auditName "slk_audit" }}
@@ -95,12 +105,12 @@ spec:
         {{- if .Values.activeactive }}
         - name: AQUA_PUBSUB_DBUSER
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.pubsubUser "postgres" }}
-          {{- if .Values.db.passwordSecret }}
+        {{- if .Values.db.passwordFromSecret.enabled }}
         - name: AQUA_PUBSUB_DBPASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.db.dbPubsubPasswordName }}
-              key: {{ .Values.db.dbPubsubPasswordKey }}
+              name: {{ .Values.db.passwordFromSecret.dbPubsubPasswordName }}
+              key: {{ .Values.db.passwordFromSecret.dbPubsubPasswordKey }}
           {{- else }}
         - name: AQUA_PUBSUB_DBPASSWORD
           valueFrom:
@@ -111,7 +121,7 @@ spec:
               {{- else }}
               key: db-password
               {{- end }}
-          {{- end }}
+        {{- end }}
         - name: AQUA_PUBSUB_DBNAME
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.pubsubName "aqua_pubsub" }}
         - name: AQUA_PUBSUB_DBHOST
@@ -146,6 +156,11 @@ spec:
         readinessProbe:
 {{ toYaml . | indent 10 }}
 {{- end }}
+        {{- if .Values.gate.TLS.enabled }}
+        volumeMounts:
+        - name: certs
+          mountPath: /opt/aquasec/ssl/
+        {{- end }}
         resources:
 {{ toYaml .Values.gate.resources | indent 12 }}
       {{- with .Values.gate.nodeSelector }}
@@ -159,4 +174,11 @@ spec:
       {{- if and (.Values.gate.tolerations) (semverCompare "^1.6-0" .Capabilities.KubeVersion.GitVersion) }}
       tolerations:
 {{ toYaml .Values.gate.tolerations | indent 6 }}
+      {{- end }}
+      {{- if .Values.gate.TLS.enabled }}
+      volumes:
+      - name: certs
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.gate.TLS.secretName }}
       {{- end }}

--- a/aqua-quickstart/templates/kube-enforcer-deployment.yaml
+++ b/aqua-quickstart/templates/kube-enforcer-deployment.yaml
@@ -13,13 +13,33 @@ spec:
       labels:
         app: {{ include "kube-enforcer.fullname" . }}
     spec:
+      {{- with .Values.ke.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       serviceAccountName: {{ .Values.ke.serviceAccount.name }}
       containers:
         - name: kube-enforcer
+          {{- with .Values.ke.container_securityContext }}
+          securityContext:
+{{ toYaml . | indent 12 }}
+          {{- end }}
           image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.ke.image.repository }}:{{ .Values.ke.image.tag }}"
           imagePullPolicy: Always
           ports:
             - containerPort: 8443
+{{- with .Values.livenessProbe }}
+          livenessProbe:
+{{ toYaml . | indent 12 }}
+{{- end }}
+{{- with .Values.readinessProbe }}
+          readinessProbe:
+{{ toYaml . | indent 12 }}
+{{- end }}
+{{- with .Values.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+{{- end }}
           env:
             - name: AQUA_TOKEN
               valueFrom: 
@@ -38,6 +58,8 @@ spec:
               value: {{ .Values.ke.envs.gatewayAddress }}
             - name: AQUA_TLS_PORT
               value: "8443"
+            - name: SCALOCK_LOG_LEVEL
+              value: {{ .Values.logLevel | default "INFO" }}
           volumeMounts:
             - name: "certs"
               mountPath: "/certs"
@@ -49,4 +71,4 @@ spec:
         - name: {{ .Values.imageCredentials.name }}
   selector:
     matchLabels:
-      app: {{ include "kube-enforcer.fullname" . }}                           
+      app: {{ include "kube-enforcer.fullname" . }}

--- a/aqua-quickstart/templates/mutating-webhook.yaml
+++ b/aqua-quickstart/templates/mutating-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Values.ke.namespace }}
 webhooks:
   - name: microenforcer.aquasec.com
+    failurePolicy: {{ .Values.ke.webhooks.failurePolicy }}
     rules:
       - operations: ["CREATE", "UPDATE"]
         apiGroups: ["*"]

--- a/aqua-quickstart/templates/openshift-route.yaml
+++ b/aqua-quickstart/templates/openshift-route.yaml
@@ -1,0 +1,44 @@
+{{- if not .Values.platform -}}
+{{ template "platform" . }}
+{{- else if and ( .Values.openshift_route.create ) (eq .Values.platform "openshift" ) }}
+---
+##webroute
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: aqua-web
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Namespace }}-web
+spec:
+  to:
+    kind: Service
+    name: {{ .Release.Namespace }}-console-svc
+    weight: 100
+  port:
+    targetPort: {{ .Release.Namespace }}-web-ssl
+  tls:
+    termination: passthrough
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None
+---
+##Gateway-route
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: {{ .Release.Namespace }}-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Namespace }}-gateway
+spec:
+  to:
+    kind: Service
+    name: {{ .Release.Namespace }}-gateway
+    weight: 100
+  port:
+    targetPort: {{ .Release.Namespace }}-gateway-ssl
+  tls:
+    termination: passthrough
+    insecureEdgeTerminationPolicy: None
+  wildcardPolicy: None
+{{- end }}

--- a/aqua-quickstart/templates/rbac.yaml
+++ b/aqua-quickstart/templates/rbac.yaml
@@ -71,4 +71,91 @@ roleRef:
   {{- else }}
   name: {{ .Release.Name }}-cluster-role
   {{- end }}
+
+{{- if not .Values.platform -}}
+{{ template "platform" .}}
+{{- else if eq .Values.platform "openshift" }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cluster-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Namespace }}-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-reader
+---
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: true
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+- SYS_ADMIN
+- NET_ADMIN
+- NET_RAW
+- SYS_PTRACE
+- KILL
+- MKNOD
+- SETGID
+- SETUID
+- SYS_MODULE
+- AUDIT_CONTROL
+- SYSLOG
+- SYS_CHROOT
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: aqua scc provides all features of the restricted SCC
+      but allows users to run with any non-root UID and access hostPath. The user must
+      specify the UID or it must be specified on the by the manifest of the container runtime.
+    release.openshift.io/create-only: "true"
+  name: aqua-scc
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:aqua:aqua-sa
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret
+- hostPath
+
+{{- else if eq .Values.platform "tkg" }}
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rolebinding-default-privileged-sa-ns_default
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: psp:vmware-system-privileged
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: system:serviceaccounts
+{{- end -}}
 {{- end }}

--- a/aqua-quickstart/templates/validating-webhook.yaml
+++ b/aqua-quickstart/templates/validating-webhook.yaml
@@ -6,7 +6,7 @@ metadata:
 webhooks:
   - name: imageassurance.aquasec.com
     rules:
-      - operations: ["CREATE", "UPDATE"]
+      - operations: ["CREATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]

--- a/aqua-quickstart/templates/web-deployment.yaml
+++ b/aqua-quickstart/templates/web-deployment.yaml
@@ -23,11 +23,17 @@ spec:
         app: {{ .Release.Name }}-console
       name: {{ .Release.Name }}-console
     spec:
+      {{- with .Values.web.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       serviceAccount: {{ .Release.Namespace }}-sa
       containers:
       - name: web
+        {{- with .Values.web.container_securityContext }}
         securityContext:
-          {{- toYaml .Values.web.securityContext | nindent 12 }}
+{{ toYaml . | indent 10 }}
+        {{- end }}
         image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
         imagePullPolicy: "{{ .Values.web.image.pullPolicy }}"
         env:
@@ -35,12 +41,12 @@ spec:
           value: {{ .Values.web.logLevel | default "INFO" }}
         - name: SCALOCK_DBUSER
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.user "postgres" }}
-        {{- if .Values.db.passwordSecret }}
+        {{- if .Values.db.passwordFromSecret.enabled }}
         - name: SCALOCK_DBPASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.db.dbPasswordName }}
-              key: {{ .Values.db.dbPasswordKey }}
+              name: {{ .Values.db.passwordFromSecret.dbPasswordName }}
+              key: {{ .Values.db.passwordFromSecret.dbPasswordKey }}
         {{- else }}
         - name: SCALOCK_DBPASSWORD
           valueFrom:
@@ -61,14 +67,13 @@ spec:
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.port "5432" | quote }}
         - name: SCALOCK_AUDIT_DBUSER
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.auditUser "postgres" }}
-          {{- if .Values.db.passwordSecret }}
         - name: SCALOCK_AUDIT_DBPASSWORD
+          {{- if .Values.db.passwordFromSecret.enabled }}
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.db.dbAuditPasswordName }}
-              key: {{ .Values.db.dbAuditPasswordKey }}
-          {{- else }}
-        - name: SCALOCK_AUDIT_DBPASSWORD
+              name: {{ .Values.db.passwordFromSecret.dbAuditPasswordName }}
+              key: {{ .Values.db.passwordFromSecret.dbAuditPasswordKey }}
+          {{- else if and ( not .Values.db.passwordFromSecret.enabled ) ( .Values.db.external.enabled ) }}
           valueFrom:
             secretKeyRef:
               name: {{ .Release.Name }}-database-password
@@ -77,6 +82,11 @@ spec:
               {{- else }}
               key: db-password
               {{- end }}
+          {{- else }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-database-password
+              key: audit-password
           {{- end }}
         - name: SCALOCK_AUDIT_DBNAME
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.auditName "slk_audit" }}
@@ -91,12 +101,12 @@ spec:
         {{- if .Values.activeactive }}
         - name: AQUA_PUBSUB_DBUSER
           value: {{ .Values.db.external.enabled | ternary .Values.db.external.pubsubUser "postgres" }}
-          {{- if .Values.db.passwordSecret }}
+          {{- if .Values.db.passwordFromSecret.enabled }}
         - name: AQUA_PUBSUB_DBPASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.db.dbPubsubPasswordName }}
-              key: {{ .Values.db.dbPubsubPasswordKey }}
+              name: {{ .Values.db.passwordFromSecret.dbPubsubPasswordName }}
+              key: {{ .Values.db.passwordFromSecret.dbPubsubPasswordKey }}
           {{- else }}
         - name: AQUA_PUBSUB_DBPASSWORD
           valueFrom:
@@ -169,6 +179,11 @@ spec:
         - mountPath: /var/run/docker.sock
           name: docker-socket-mount
         {{- end }}
+        {{- if .Values.web.TLS.enabled }}
+        volumeMounts:
+        - name: certs
+          mountPath: /opt/aquasec/ssl/
+        {{- end }}
         resources:
 {{ toYaml .Values.web.resources | indent 12 }}
       {{- with .Values.web.nodeSelector }}
@@ -188,4 +203,11 @@ spec:
       - name: docker-socket-mount
         hostPath:
           path: {{ .Values.dockerSock.path }}
+      {{- end }}
+      {{- if .Values.web.TLS.enabled }}
+      volumes:
+      - name: certs
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.web.TLS.secretName }}
       {{- end }}

--- a/aqua-quickstart/templates/web-secrets.yaml
+++ b/aqua-quickstart/templates/web-secrets.yaml
@@ -9,8 +9,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-metadata:
-  name: {{ .Release.Name }}-console-secrets
 type: Opaque
 data:
 {{- if .Values.admin.password }}

--- a/aqua-quickstart/values.yaml
+++ b/aqua-quickstart/values.yaml
@@ -12,8 +12,20 @@ rbac:
   privileged: true
   roleRef:
 
+#Please specify k8s platform acronym. Allowed values are aks, eks, gke, openshift, tkg, tkgi, k8s
+# aks = Azure Kubernetes Service
+# gke = Google kubernetes Engine
+# openshift = RedHat Openshift/OCP
+# tkg = VMware Tanzu kubernetes Grid
+# tkgi = VMware Tanzu kubernetes Grid Integrated Edition
+# k8s = Plain/on-prem Vanilla Kubernetes
+platform:
+
+openshift_route:
+  create: false    #Enable if required openshift route for web and gateway
+
 # enable only one of the modes
-clustermode: 
+clustermode:
 activeactive:
 
 admin:
@@ -57,10 +69,27 @@ ke:
     name: aqua-kube-enforcer 
   webhooks:
     caBundle: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFVENDQWZtZ0F3SUJBZ0lVTkljWmkzL2xqbEtObFZ0WXBwVyttN2xWZnNVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0Z6RVZNQk1HQTFVRUF3d01ZV1J0YVhOemFXOXVYMk5oTUNBWERUSXdNRGd5TnpBNU5EZ3dNMW9ZRHpJeQpPVFF3TmpFeU1EazBPREF6V2pBWE1SVXdFd1lEVlFRRERBeGhaRzFwYzNOcGIyNWZZMkV3Z2dFaU1BMEdDU3FHClNJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUURZSlovRmRjVUtDdmdqSHlVVnhxWitRTTBRLzNGYzQyTzkKUGlXTllGS2l3L1FJTUIxTHZpQklXSFQyVEZLRkVYYUtZcmdzTHE0MElFZWMyN2Jvd2RTbXJVZEV3bEdtNkQrMQpIaGROQWI4WEllWTNteEpUUlR2cVhzYitrUnptYjJCL2xRVVlLNFJxaW8vN2RyZjFEYjBwWEFYVmxzRFNvQUhoCkxUWUxXbmhldGNLTUEvT3FCQXBoaWM4VzZZN1VJY2FtWnVZZUMxOVBlMlZKSHFxZ3o5MDNybjFGTnNMWnA4Q00Kb0dXeENEU0RFSWRuTmMxVis1WUg4VmxLRk9wb2IxYWtIZFFPeVlROFVPR2hnMHh3YXNGMnRRc2RCQ3BTUFBNYwo3K01kWnF0c2dtVGJQaUN6bWRra25uWWZ4cmxsWVVmOGFCelBrMzhyQ2ZiMnF5ZHJLTGZSQWdNQkFBR2pVekJSCk1CMEdBMVVkRGdRV0JCVDlDWlVURzRtQThrYzBISEJsamhRZUxKWjZoekFmQmdOVkhTTUVHREFXZ0JUOUNaVVQKRzRtQThrYzBISEJsamhRZUxKWjZoekFQQmdOVkhSTUJBZjhFQlRBREFRSC9NQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFDUE5Ick5rcTBpN2tpMnNGcUtWa3l0RGpRWTFzaVNRcjNsbXVweDlVL1FuaytBQ2huYUhjNDVqSFVTCi9JdmNWMnljQVZ1aUQ3eFJXWkdYVzRuRE14QjdBZ0RKWmhJd3hGTVl1bVpGZEtCUlBLKy9WY3ZFTFFoZ3Z6T0QKNWhvNHZ0RzlHTzBDUzhqNUtGZ3pWaDgxcmsyU2c1RDN6TGVISjVVNDVRK2xlRGtldXJmMzFqQWJsMU1vai9JWgpndVUyd1Y5RkJJaFZONTMwd1Y4b01oWnVZRWZvUmZhOEpIbXhTMmNNbHUxQWZ5YmZkcFB2cCtpUHZKc0t2UTgzCmdueEd4K1k5NldzL0pmWDlXSFpBT1kyQXVVYS9hUjZLSnVraG9KVTk2Z3p5VXd0eFV5aWExdDg5M0hZNmQ3bG0KU1BmaVEzWm40dXdxaEczMUhGSmZMMG5iSmlxZQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+    failurePolicy: Ignore
     validatingWebhook:
       name: kube-enforcer-admission-hook-config
     mutatingWebhook:
       name: kube-enforcer-me-injection-hook-config
+  securityContext:
+    runAsUser: 11431
+    runAsGroup: 11433
+    fsGroup: 11433
+  container_securityContext: {}
+  livenessProbe:
+    tcpSocket:
+      port: 8080
+    initialDelaySeconds: 60
+    periodSeconds: 30
+
+  readinessProbe:
+    tcpSocket:
+      port: 8080
+    initialDelaySeconds: 60
+    periodSeconds: 30
 
 db:
   external:
@@ -74,21 +103,29 @@ db:
     auditHost:
     auditPort:
     auditUser:
-    auditPassword: true
+    auditPassword:
     pubsubName:
     pubsubHost:
     pubsubPort:
     pubsubUser:
     pubsubPassword:
-  passwordSecret:
-  dbPasswordName:
-  dbPasswordKey:
-  dbAuditPasswordName:
-  dbAuditPasswordKey:
-  dbPubsubPasswordName:
-  dbPubsubPasswordKey:
+
+  passwordFromSecret:
+    enabled: false              #Enable if loading passwords for db and audit-db from secret
+    dbPasswordName:             #Specify the Password Secret name used for db password
+    dbPasswordKey:              #Specify the db password key name stored in the #dbPasswordName secret
+    dbAuditPasswordName:           #Specify the Password Secret name used for audit db password
+    dbAuditPasswordKey:             #Specify the audit db password key name stored in the #dbAuditPasswordName secret
+    dbPubsubPasswordName:            #Specify the Password Secret name used for pubsub db password
+    dbPubsubPasswordKey:            #Specify the pubsub db password key name stored in the #PubsubPasswordName secret
   ssl: false
   auditssl: false
+  securityContext:
+    runAsUser: 70
+    runAsGroup: 70
+    fsGroup: 11433
+  container_securityContext:
+    privileged: false
   image:
     repository: database
     tag: "5.3"
@@ -129,7 +166,6 @@ db:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  securityContext: {}
 
   # extraEnvironmentVars is a list of extra environment variables to set in the database deployments.
   extraEnvironmentVars: {}
@@ -144,6 +180,7 @@ db:
 
 gate:
   replicaCount: 1
+  logLevel:
   image:
     repository: gateway
     tag: "5.3"
@@ -178,7 +215,7 @@ gate:
     tcpSocket:
       port: 8443
     initialDelaySeconds: 60
-    periodSeconds: 30
+    periodSeconds: 60
   resources: {}
     # Note: For recommendations please check the official sizing guide.
     # requests:
@@ -190,15 +227,24 @@ gate:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  securityContext: {}
-  #  runAsUser: 11431
-  #  runAsGroup: 11433
-  #  fsGroup: 11433
+  securityContext:
+    runAsUser: 11431
+    runAsGroup: 11433
+    fsGroup: 11433
+  container_securityContext: {}
+
+  TLS:
+    enabled: false      # change to true for enabling secure communication
+    secretName:         #created certs secret name for gate
+    #Follow Advance configuration for mTLS communication establishment and place your certs in /opt/aquasec/ssl/ path
 
   # extraEnvironmentVars is a list of extra environment variables to set in the gateway deployments.
   # https://docs.aquasec.com/docs/gateway-optional-variables
   extraEnvironmentVars: {}
     # ENV_NAME: value
+    #Example for mTLS env variables:
+    #AQUA_PUBLIC_KEY: "/opt/aquasec/ssl/<file_name>"
+    #AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/<file_name>"
 
   # extraSecretEnvironmentVars is a list of extra environment variables to set in the gateway deployments.
   # These variables take value from existing Secret objects.
@@ -209,6 +255,7 @@ gate:
 
 web:
   replicaCount: 1
+  logLevel:
   image:
     repository: console
     tag: "5.3"
@@ -229,6 +276,7 @@ web:
         protocol: TCP
   ingress:
     enabled: false
+    externalPort:
     annotations: {}
     #  kubernetes.io/ingress.class: nginx
     hosts: #REQUIRED
@@ -237,6 +285,7 @@ web:
     #  - secretName: aquasec-tls
     #    hosts:
     #      - aquasec.domain.com
+
   # Note: Please change the ports according to the requirement.
   # default liveness and readiness probe
   livenessProbe:
@@ -252,6 +301,7 @@ web:
       port: 8080
     initialDelaySeconds: 60
     periodSeconds: 30
+
   resources: {}
     # Note: For recommendations please check the official sizing guide.
     # requests:
@@ -263,10 +313,17 @@ web:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  securityContext: {}
-  #  runAsUser: 11431
-  #  runAsGroup: 11433
-  #  fsGroup: 11433
+  securityContext:
+    runAsUser: 11431
+    runAsGroup: 11433
+    fsGroup: 11433
+  container_securityContext: {}
+
+
+  TLS:
+    enabled: false      # change to true for enabling secure communication
+    secretName:         #created certs secret name for web
+    #Follow Advance configuration for mTLS communication establishment and place your certs in /opt/aquasec/ssl/
 
   # extraEnvironmentVars is a list of extra environment variables to set in the web deployments.
   # https://docs.aquasec.com/docs/server-optional-variables
@@ -276,6 +333,9 @@ web:
     BATCH_INSTALL_GATEWAY: "aqua-gateway"
   }
     # ENV_NAME: value
+    #Example for mTLS env variables:
+    #AQUA_PUBLIC_KEY: "/opt/aquasec/ssl/<file_name>"
+    #AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/<file_name>"
 
   # extraSecretEnvironmentVars is a list of extra environment variables to set in the web deployments.
   # These variables take value from existing Secret objects.
@@ -292,16 +352,11 @@ envoy:
     repository: envoyproxy/envoy-alpine
     tag: v1.15.0
     pullPolicy: IfNotPresent
-  
+
   service:
     type: LoadBalancer
     annotations: {}
     ports:
-    - name: healthserver
-      port: 8082
-      targetPort: 8082
-      nodePort:
-      protocol: TCP
     - name: https
       port: 443
       targetPort: 8443
@@ -336,7 +391,7 @@ envoy:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
-  
+
   resources: {}
     # Note: For recommendations please check the official sizing guide.
     # requests:

--- a/server/templates/rbac.yaml
+++ b/server/templates/rbac.yaml
@@ -47,6 +47,7 @@ rules:
   resources: ["*"]
   verbs: ["get", "list", "watch"]
 {{- end }}
+
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
adding all the recent updates to quick-start yamls.
1. security context / non-privileged mode 
2. openshift route
3. db existing secrets
4. fixing envoy
