### PR TITLE
Enhancement: Kube-Enforcer certs secret consistent with imagePullCreds secret

### DIFF
--- a/kube-enforcer/README.md
+++ b/kube-enforcer/README.md
@@ -96,7 +96,7 @@ Optionally, you can provide these certificates in base64 encoded format as flags
    Next, run the following command:
    
    ```shell
-   helm upgrade --install --namespace aqua kube-enforcer ./kube-enforcer --set evs.gatewayAddress="<Aqua_Remote_Gateway_IP/URL>",imageCredentials.username=<registry-username>,imageCredentials.password=<registry-password>
+   helm upgrade --install --namespace aqua kube-enforcer ./kube-enforcer --set envs.gatewayAddress="<Aqua_Remote_Gateway_IP/URL>",imageCredentials.username=<registry-username>,imageCredentials.password=<registry-password>
    ```
 
 Optional flags:
@@ -118,19 +118,19 @@ To perform kube-bench scans in the cluster, the KubeEnforcer needs:
 
 ## Configurable parameters
 
-| Parameter                         | Description                                                                 | Default                 | Mandatory               |
-| --------------------------------- | --------------------------------------------------------------------------- | ----------------------- | ----------------------- |
-| `imageCredentials.create`         | Set to create new pull image secret                                         | `true`                  | `YES - New cluster`     |
-| `imageCredentials.name`           | Your Docker pull image secret name                                          | `aqua-registry-secret`  | `YES - New cluster`     |
-| `imageCredentials.username`       | Your Docker registry (DockerHub, etc.) username                             | `N/A`                   | `YES - New cluster`     |
-| `imageCredentials.password`       | Your Docker registry (DockerHub, etc.) password                             | `N/A`                   | `YES - New cluster`     |
-| `aquaSecret.kubeEnforcerToken`    | Aqua KubeEnforcer token                                                     | `N/A`                   | `YES`                   |
-| `certsSecret.serverCertificate`   | Certificate for TLS authentication with the Kubernetes api-server           | `N/A`                   | `YES`                   |
-| `certsSecret.serverKey`           | Certificate key for TLS authentication with the Kubernetes api-server       | `N/A`                   | `YES`                   |
-| `webhooks.caBundle`               | Root certificate for TLS authentication with the Kubernetes api-server      | `N/A`                   | `YES`                   |
-| `envs.gatewayAddress`             | Gateway host address                                                        | `aqua-gateway-svc:8443` | `YES`                   |
-| `existing_secret.enable`          | To use existing secret for KE certs                                         | `false`                 | `NO`                    |
-| `existing_secret.secretName`      | existing secret name for KE certs                                           | `N/A`                   | `NO`                    |
+| Parameter                         | Description                                                                 | Default                   | Mandatory               |
+| --------------------------------- | --------------------------------------------------------------------------- | ------------------------- | ----------------------- |
+| `imageCredentials.create`         | Set to create new pull image secret                                         | `true`                    | `YES - New cluster`     |
+| `imageCredentials.name`           | Your Docker pull image secret name                                          | `aqua-registry-secret`    | `YES - New cluster`     |
+| `imageCredentials.username`       | Your Docker registry (DockerHub, etc.) username                             | `N/A`                     | `YES - New cluster`     |
+| `imageCredentials.password`       | Your Docker registry (DockerHub, etc.) password                             | `N/A`                     | `YES - New cluster`     |
+| `aquaSecret.kubeEnforcerToken`    | Aqua KubeEnforcer token                                                     | `N/A`                     | `YES`                   |
+| `certsSecret.create`              | Set to create new secret for KE certs                                       | `true`                    | `YES`                   |
+| `certsSecret.name`                | Secret name for KE certs                                                    | `aqua-kube-enforcer-certs`| `YES`                    |
+| `certsSecret.serverCertificate`   | Certificate for TLS authentication with the Kubernetes api-server           | `N/A`                     | `YES`                   |
+| `certsSecret.serverKey`           | Certificate key for TLS authentication with the Kubernetes api-server       | `N/A`                     | `YES`                   |
+| `webhooks.caBundle`               | Root certificate for TLS authentication with the Kubernetes api-server      | `N/A`                     | `YES`                   |
+| `envs.gatewayAddress`             | Gateway host address                                                        | `aqua-gateway-svc:8443`   | `YES`                   |
 
 ## Issues and feedback
 

--- a/kube-enforcer/templates/_helpers.tpl
+++ b/kube-enforcer/templates/_helpers.tpl
@@ -47,6 +47,6 @@ Create chart name and version as used by the chart label.
 {{- printf "%s" (required "A valid .Values.webhooks.caBundle entry required" .Values.webhooks.caBundle) | replace "\n" "" }}
 {{- end }}
 
-{{- define "existing_secret" }}
-{{- printf "%s" (required "A valid .Values.existing_secret.secretName required" .Values.existing_secret.secretName ) }}
+{{- define "certsSecret_name" }}
+{{- printf "%s" (required "A valid .Values.certsSecret.name required" .Values.certsSecret.name) }}
 {{- end }}

--- a/kube-enforcer/templates/kube-enforcer-certs.yaml
+++ b/kube-enforcer/templates/kube-enforcer-certs.yaml
@@ -1,4 +1,7 @@
-{{- if not .Values.existing_secret.enable }}
+{{- if not .Values.certsSecret.name}}
+{{ template "certsSecret_name" . }}
+{{- end }}
+{{- if .Values.certsSecret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,6 +10,4 @@ metadata:
 data:
   server.crt: {{ template "serverCertificate" . }}  # place server cert
   server.key: {{ template "serverKey" . }}  # place server key
-{{- else if not .Values.existing_secret.secretName }}
-{{ template "existing_secret" . }}
 {{- end }}

--- a/kube-enforcer/templates/kube-enforcer-deployment.yaml
+++ b/kube-enforcer/templates/kube-enforcer-deployment.yaml
@@ -66,11 +66,7 @@ spec:
       volumes:
         - name: "certs"
           secret:
-{{- if .Values.existing_secret.enable }}
-            secretName: {{ .Values.existing_secret.secretName }}
-{{- else }}
             secretName: {{ .Values.certsSecret.name }}
-{{- end }}
       imagePullSecrets:
         - name: {{ .Values.imageCredentials.name }}
   selector:

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -27,12 +27,9 @@ namespace: "aqua"
 
 logLevel:
 
-#enable to true if you want to use existing secret for the cluster
-existing_secret:
-  enable: false
-  secretName: ""
-
+# Set create to false if you want to use an existing secret for the kube-enforcer certs
 certsSecret:
+  create: true
   name: aqua-kube-enforcer-certs
   serverCertificate: ""
   serverKey: ""

--- a/scanner/README.md
+++ b/scanner/README.md
@@ -56,6 +56,7 @@ Parameter | Description | Default| Mandatory
 `dockerSocket.mount` | boolean parameter if to mount docker socket | `unset`| `NO` 
 `dockerSocket.path` | docker socket path | `/var/run/docker.sock`| `NO` 
 `serviceAccount` | k8s service account to use | `aqua-sa`| `YES` 
+`server.scheme` | scheme for server to connect | `http`| `NO`
 `server.serviceName` | service name for server to connect | `aqua-console-svc`| `YES` 
 `server.port` | service port for server to connect | `8080`| `YES` 
 `image.repository` | the docker image name to use | `scanner`| `YES` 

--- a/scanner/templates/scanner-deployment.yaml
+++ b/scanner/templates/scanner-deployment.yaml
@@ -48,7 +48,7 @@ spec:
         - --password
         - "{{ required "Please specify a password for a user associated with the Scanner role" .Values.password }}"
         - --host
-        - "http://{{ .Values.server.serviceName }}:{{ .Values.server.port }}"
+        - "{{ .Values.server.scheme | default "http" }}://{{ .Values.server.serviceName }}:{{ .Values.server.port }}"
         env:
         - name: SCALOCK_LOG_LEVEL
           value: {{ .Values.logLevel | default "INFO" }}
@@ -94,7 +94,7 @@ spec:
         hostPath:
           path: {{ .Values.dockerSock.path }}
       {{- end }}
-      {{- if not .Values.aquaCluster }}
+      {{- if .Values.imageCredentials.create }}
       imagePullSecrets:
         - name: {{ .Values.imageCredentials.name }}
       {{- end }}

--- a/scanner/values.yaml
+++ b/scanner/values.yaml
@@ -16,6 +16,7 @@ dockerSock:
 serviceAccount: "aqua-sa"
 
 server:
+  scheme: ""  #specify the schema for the server host URL, default it is http; Change it to https for connecting
   serviceName: "aqua-console-svc" # example
   port: 8080
 

--- a/tenant-manager/templates/db-deployment.yaml
+++ b/tenant-manager/templates/db-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       securityContext:
 {{ toYaml . | indent 8 }}
       {{- end }}
-      serviceAccount: {{ .Release.Namespace }}-sa
+      serviceAccount: {{ .Release.Name }}-sa
       initContainers:
       - name: {{ .Release.Name }}-db-init
         env:
@@ -104,3 +104,5 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-tm-db-pvc
 {{- end }}
+      imagePullSecrets:
+        - name: {{ .Values.imageCredentials.name }}

--- a/tenant-manager/templates/image-pull-secret.yaml
+++ b/tenant-manager/templates/image-pull-secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.imageCredentials.create -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.imageCredentials.name }}
+  labels:
+    app: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "imagePullSecret" . }}
+{{- end -}}

--- a/tenant-manager/templates/serviceaccount.yaml
+++ b/tenant-manager/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-sa
+  labels:
+    app: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"

--- a/tenant-manager/templates/tm-deploy.yaml
+++ b/tenant-manager/templates/tm-deploy.yaml
@@ -27,7 +27,7 @@ spec:
       securityContext:
 {{ toYaml . | indent 8 }}
       {{- end }}
-      serviceAccount: {{ .Release.Namespace }}-sa
+      serviceAccount: {{ .Release.Name }}-sa
       containers:
       - name: tenantmanager
         {{- with .Values.tenantmanager.container_securityContext }}
@@ -151,3 +151,5 @@ spec:
           defaultMode: 420
           secretName: {{ .Values.tenantmanager.TLS.secretName }}
       {{- end }}
+      imagePullSecrets:
+        - name: {{ .Values.imageCredentials.name }}


### PR DESCRIPTION
### Description
The kube enforcer chart allows to manage the following 2 secrets in different ways:
* imageCredentials
* certsSecret

In the first case this flag enables/disables:
```
imageCredentials:
  create: true
  name: "name"
```

in the second case instead there in an additional block to do this, with a duplicated name field:
```
existing_secret:
  enable: true
  secretName: ""

certsSecret:
  name: aqua-kube-enforcer-certs
```
Also, `existing_secret` block is a little vague and doesn't immediately connect to the creation of the certs secret.

### Enhancement
The proposed change will make the way to enable/disable secrets creation consistent, removing the `existing_secret` block.
```
certsSecret:
  create: true
  name: "name"
```


