### PR TITLE
Enhancement: Kube-Enforcer certs secret consistent with imagePullCreds secret

### DIFF
--- a/kube-enforcer/README.md
+++ b/kube-enforcer/README.md
@@ -96,7 +96,7 @@ Optionally, you can provide these certificates in base64 encoded format as flags
    Next, run the following command:
    
    ```shell
-   helm upgrade --install --namespace aqua kube-enforcer ./kube-enforcer --set evs.gatewayAddress="<Aqua_Remote_Gateway_IP/URL>",imageCredentials.username=<registry-username>,imageCredentials.password=<registry-password>
+   helm upgrade --install --namespace aqua kube-enforcer ./kube-enforcer --set envs.gatewayAddress="<Aqua_Remote_Gateway_IP/URL>",imageCredentials.username=<registry-username>,imageCredentials.password=<registry-password>
    ```
 
 Optional flags:
@@ -118,19 +118,19 @@ To perform kube-bench scans in the cluster, the KubeEnforcer needs:
 
 ## Configurable parameters
 
-| Parameter                         | Description                                                                 | Default                 | Mandatory               |
-| --------------------------------- | --------------------------------------------------------------------------- | ----------------------- | ----------------------- |
-| `imageCredentials.create`         | Set to create new pull image secret                                         | `true`                  | `YES - New cluster`     |
-| `imageCredentials.name`           | Your Docker pull image secret name                                          | `aqua-registry-secret`  | `YES - New cluster`     |
-| `imageCredentials.username`       | Your Docker registry (DockerHub, etc.) username                             | `N/A`                   | `YES - New cluster`     |
-| `imageCredentials.password`       | Your Docker registry (DockerHub, etc.) password                             | `N/A`                   | `YES - New cluster`     |
-| `aquaSecret.kubeEnforcerToken`    | Aqua KubeEnforcer token                                                     | `N/A`                   | `YES`                   |
-| `certsSecret.serverCertificate`   | Certificate for TLS authentication with the Kubernetes api-server           | `N/A`                   | `YES`                   |
-| `certsSecret.serverKey`           | Certificate key for TLS authentication with the Kubernetes api-server       | `N/A`                   | `YES`                   |
-| `webhooks.caBundle`               | Root certificate for TLS authentication with the Kubernetes api-server      | `N/A`                   | `YES`                   |
-| `envs.gatewayAddress`             | Gateway host address                                                        | `aqua-gateway-svc:8443` | `YES`                   |
-| `existing_secret.enable`          | To use existing secret for KE certs                                         | `false`                 | `NO`                    |
-| `existing_secret.secretName`      | existing secret name for KE certs                                           | `N/A`                   | `NO`                    |
+| Parameter                         | Description                                                                 | Default                   | Mandatory               |
+| --------------------------------- | --------------------------------------------------------------------------- | ------------------------- | ----------------------- |
+| `imageCredentials.create`         | Set to create new pull image secret                                         | `true`                    | `YES - New cluster`     |
+| `imageCredentials.name`           | Your Docker pull image secret name                                          | `aqua-registry-secret`    | `YES - New cluster`     |
+| `imageCredentials.username`       | Your Docker registry (DockerHub, etc.) username                             | `N/A`                     | `YES - New cluster`     |
+| `imageCredentials.password`       | Your Docker registry (DockerHub, etc.) password                             | `N/A`                     | `YES - New cluster`     |
+| `aquaSecret.kubeEnforcerToken`    | Aqua KubeEnforcer token                                                     | `N/A`                     | `YES`                   |
+| `certsSecret.create`              | Set to create new secret for KE certs                                       | `true`                    | `YES`                   |
+| `certsSecret.name`                | Secret name for KE certs                                                    | `aqua-kube-enforcer-certs`| `YES`                    |
+| `certsSecret.serverCertificate`   | Certificate for TLS authentication with the Kubernetes api-server           | `N/A`                     | `YES`                   |
+| `certsSecret.serverKey`           | Certificate key for TLS authentication with the Kubernetes api-server       | `N/A`                     | `YES`                   |
+| `webhooks.caBundle`               | Root certificate for TLS authentication with the Kubernetes api-server      | `N/A`                     | `YES`                   |
+| `envs.gatewayAddress`             | Gateway host address                                                        | `aqua-gateway-svc:8443`   | `YES`                   |
 
 ## Issues and feedback
 

--- a/kube-enforcer/templates/_helpers.tpl
+++ b/kube-enforcer/templates/_helpers.tpl
@@ -47,6 +47,6 @@ Create chart name and version as used by the chart label.
 {{- printf "%s" (required "A valid .Values.webhooks.caBundle entry required" .Values.webhooks.caBundle) | replace "\n" "" }}
 {{- end }}
 
-{{- define "existing_secret" }}
-{{- printf "%s" (required "A valid .Values.existing_secret.secretName required" .Values.existing_secret.secretName ) }}
+{{- define "certsSecret_name" }}
+{{- printf "%s" (required "A valid .Values.certsSecret.name required" .Values.certsSecret.name) }}
 {{- end }}

--- a/kube-enforcer/templates/kube-enforcer-certs.yaml
+++ b/kube-enforcer/templates/kube-enforcer-certs.yaml
@@ -1,4 +1,7 @@
-{{- if not .Values.existing_secret.enable }}
+{{- if not .Values.certsSecret.name}}
+{{ template "certsSecret_name" . }}
+{{- end }}
+{{- if .Values.certsSecret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,6 +10,4 @@ metadata:
 data:
   server.crt: {{ template "serverCertificate" . }}  # place server cert
   server.key: {{ template "serverKey" . }}  # place server key
-{{- else if not .Values.existing_secret.secretName }}
-{{ template "existing_secret" . }}
 {{- end }}

--- a/kube-enforcer/templates/kube-enforcer-deployment.yaml
+++ b/kube-enforcer/templates/kube-enforcer-deployment.yaml
@@ -66,11 +66,7 @@ spec:
       volumes:
         - name: "certs"
           secret:
-{{- if .Values.existing_secret.enable }}
-            secretName: {{ .Values.existing_secret.secretName }}
-{{- else }}
             secretName: {{ .Values.certsSecret.name }}
-{{- end }}
       imagePullSecrets:
         - name: {{ .Values.imageCredentials.name }}
   selector:

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -27,12 +27,9 @@ namespace: "aqua"
 
 logLevel:
 
-#enable to true if you want to use existing secret for the cluster
-existing_secret:
-  enable: false
-  secretName: ""
-
+# Set create to false if you want to use an existing secret for the kube-enforcer certs
 certsSecret:
+  create: true
   name: aqua-kube-enforcer-certs
   serverCertificate: ""
   serverKey: ""


### PR DESCRIPTION
### Description
The kube enforcer chart allows to manage the following 2 secrets in different ways:
* imageCredentials
* certsSecret

In the first case this flag enables/disables:
```
imageCredentials:
  create: true
  name: "name"
```

in the second case instead there in an additional block to do this, with a duplicated name field:
```
existing_secret:
  enable: true
  secretName: ""

certsSecret:
  name: aqua-kube-enforcer-certs
```
Also, `existing_secret` block is a little vague and doesn't immediately connect to the creation of the certs secret.

### Enhancement
The proposed change will make the way to enable/disable secrets creation consistent, removing the `existing_secret` block.
```
certsSecret:
  create: true
  name: "name"
```