### PR TITLE
6.0 | KE timeouts && maintenance DB env

### DIFF
--- a/aqua-quickstart/templates/mutating-webhook.yaml
+++ b/aqua-quickstart/templates/mutating-webhook.yaml
@@ -16,3 +16,4 @@ webhooks:
         namespace: {{ .Values.ke.namespace }}
         name: {{ include "kube-enforcer.fullname" . }}
         path: "/mutate"
+    timeoutSeconds: 5

--- a/aqua-quickstart/templates/validating-webhook.yaml
+++ b/aqua-quickstart/templates/validating-webhook.yaml
@@ -15,3 +15,4 @@ webhooks:
       service:
         namespace: {{ .Values.ke.namespace }}
         name: {{ include "kube-enforcer.fullname" . }}
+    timeoutSeconds: 5

--- a/kube-enforcer/templates/mutating-webhook.yaml
+++ b/kube-enforcer/templates/mutating-webhook.yaml
@@ -17,3 +17,4 @@ webhooks:
         namespace: {{ .Values.namespace }}
         name: {{ include "kube-enforcer.fullname" . }}
         path: "/mutate"
+    timeoutSeconds: 5

--- a/kube-enforcer/templates/validating-webhook.yaml
+++ b/kube-enforcer/templates/validating-webhook.yaml
@@ -16,3 +16,4 @@ webhooks:
       service:
         namespace: {{ .Values.namespace }}
         name: {{ include "kube-enforcer.fullname" . }}
+    timeoutSeconds: 5

--- a/server/templates/web-deployment.yaml
+++ b/server/templates/web-deployment.yaml
@@ -159,6 +159,10 @@ spec:
               name: {{ .Release.Name }}-console-secrets
               key: admin-password
         {{- end }}
+        {{- if .Values.web.maintenance_db.name }}
+        - name: AQUA_MAINTENANCE_DBNAME
+          value: {{ .Values.web.maintenance_db.name }}
+        {{- end }}
         {{- include "server.extraEnvironmentVars" .Values.web | nindent 8 }}
         {{- include "server.extraSecretEnvironmentVars" .Values.web | nindent 8 }}
         ports:

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -270,6 +270,10 @@ web:
 
   # extraEnvironmentVars is a list of extra environment variables to set in the web deployments.
   # https://docs.aquasec.com/docs/server-optional-variables
+
+  maintenance_db:
+    name: ""         #specify the AQUA_MAINTENANCE_DB name if enabled
+
   extraEnvironmentVars: {}
     # ENV_NAME: value
     #Example for mTLS env variables:


### PR DESCRIPTION
adding timeouts for kubeenforcer Validating and Mutating webhook.
aqua_maintenance_db env in server chart.