### PR TITLE
6.2 | fixing scanner serviceaccount bug & KE imagesecrets bug

### DIFF
--- a/aqua-quickstart/values.yaml
+++ b/aqua-quickstart/values.yaml
@@ -31,7 +31,7 @@ ke:
   aqua_cache_expiration_period: 60
   image:
     repository: kube-enforcer
-    tag: "6.2.preview5"
+    tag: "6.2.preview6"
     pullPolicy: Always
   nameOverride: "aqua-kube-enforcer"
   fullnameOverride: "aqua-kube-enforcer"
@@ -91,7 +91,7 @@ db:
   auditssl: false
   image:
     repository: database
-    tag: "6.2.preview5"
+    tag: "6.2.preview6"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP
@@ -146,7 +146,7 @@ gate:
   replicaCount: 1
   image:
     repository: gateway
-    tag: "6.2.preview5"
+    tag: "6.2.preview6"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP
@@ -211,7 +211,7 @@ web:
   replicaCount: 1
   image:
     repository: console
-    tag: "6.2.preview5"
+    tag: "6.2.preview6"
     pullPolicy: IfNotPresent
   service:
     type: LoadBalancer

--- a/enforcer/README.md
+++ b/enforcer/README.md
@@ -143,7 +143,7 @@ multi_cluster` | Set if to create new service account | `false` | `YES - New clu
 `gate.host` | gateway host | `aqua-gateway-svc`| `YES` 
 `gate.port` | gateway port | `8443`| `YES` 
 `image.repository` | the docker image name to use | `enforcer`| `YES` 
-`image.tag` | The image tag to use. | `6.2.preview5`| `YES` 
+`image.tag` | The image tag to use. | `6.2.preview6`| `YES` 
 `image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`| `NO` 
 `resources` |	Resource requests and limits | `{}`| `NO` 
 `nodeSelector` |	Kubernetes node selector	| `{}`| `NO` 

--- a/enforcer/values.yaml
+++ b/enforcer/values.yaml
@@ -52,7 +52,7 @@ multi_gates:  # use the below hosts to add multiple gateways as required to enfo
 
 image:
   repository: enforcer
-  tag: "6.2.preview5"
+  tag: "6.2.preview6"
   pullPolicy: IfNotPresent
 
 livenessProbe: {}

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -98,7 +98,7 @@ Parameter | Description | Default
 `db.ssl` | If require an SSL-encrypted connection to the Postgres configuration database. |	`true`
 `db.auditssl` | If require an SSL-encrypted connection to the Postgres configuration database. |	`true`
 `gate.image.repository` | the docker image name to use | `gateway`
-`gate.image.tag` | The image tag to use. | `6.2.preview5`
+`gate.image.tag` | The image tag to use. | `6.2.preview6`
 `gate.image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`
 `gate.service.type` | k8s service type | `ClusterIP`
 `gate.service.ports` | array of ports settings | `array`

--- a/gateway/values.yaml
+++ b/gateway/values.yaml
@@ -52,7 +52,7 @@ gate:
   logLevel:
   image:
     repository: gateway
-    tag: "6.2.preview5"
+    tag: "6.2.preview6"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP

--- a/kube-enforcer/templates/_helpers.tpl
+++ b/kube-enforcer/templates/_helpers.tpl
@@ -50,3 +50,7 @@ Create chart name and version as used by the chart label.
 {{- define "certsSecret_name" }}
 {{- printf "%s" (required "A valid .Values.certsSecret.name required" .Values.certsSecret.name ) }}
 {{- end }}
+
+{{- define "imageCredentials_name" }}
+{{- printf "%s" (required "A valid .Values.imageCredentials.name required" .Values.imageCredentials.name ) }}
+{{- end }}

--- a/kube-enforcer/templates/kube-enforcer-deployment.yaml
+++ b/kube-enforcer/templates/kube-enforcer-deployment.yaml
@@ -124,8 +124,6 @@ spec:
         - name: "envoy-shared"
           emptyDir: {}
 {{- end }}
-      imagePullSecrets:
-        - name: {{ .Values.imageCredentials.name }}
   selector:
     matchLabels:
       app: {{ include "kube-enforcer.fullname" . }}

--- a/kube-enforcer/templates/service-account.yaml
+++ b/kube-enforcer/templates/service-account.yaml
@@ -9,4 +9,8 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   namespace: {{ .Values.namespace }}
-
+imagePullSecrets:
+{{- if not .Values.imageCredentials.name }}
+{{ template "imageCredentials_name" . }}
+{{- end }}
+- name: {{ .Values.imageCredentials.name }}

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -17,7 +17,7 @@ aqua_cache_expiration_period: 60
 
 image:
   repository: kube-enforcer
-  tag: "6.2.preview5"
+  tag: "6.2.preview6"
   pullPolicy: Always
 
 nameOverride: "aqua-kube-enforcer"

--- a/scanner/README.md
+++ b/scanner/README.md
@@ -78,7 +78,7 @@ Parameter | Description | Default| Mandatory
 `server.serviceName` | service name for server to connect | `aqua-console-svc`| `YES` 
 `server.port` | service port for server to connect | `8080`| `YES` 
 `image.repository` | the docker image name to use | `scanner`| `YES` 
-`image.tag` | The image tag to use. | `6.2.preview5`| `YES` 
+`image.tag` | The image tag to use. | `6.2.preview6`| `YES` 
 `image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`| `NO` 
 `user` | scanner username | `unset`| `YES` 
 `password` | scanner password | `unset`| `YES` 

--- a/scanner/README.md
+++ b/scanner/README.md
@@ -72,7 +72,8 @@ Parameter | Description | Default| Mandatory
 `repositoryUriPrefix` | repository uri prefix for dockerhub set `docker.io` | `registry.aquasec.com`| `YES` 
 `dockerSocket.mount` | boolean parameter if to mount docker socket | `unset`| `NO` 
 `dockerSocket.path` | docker socket path | `/var/run/docker.sock`| `NO` 
-`serviceAccount` | k8s service account to use | `aqua-sa`| `YES` 
+`serviceAccount.create` | Enable to create serviceaccount if not exist in the k8s | `false`| `NO`
+`serviceAccount.name` | K8 service-account name either existing one or new name if create is enabled | `aqua-sa`  | `YES`
 `server.scheme` | scheme for server to connect | `http`| `NO`
 `server.serviceName` | service name for server to connect | `aqua-console-svc`| `YES` 
 `server.port` | service port for server to connect | `8080`| `YES` 

--- a/scanner/templates/_helpers.tpl
+++ b/scanner/templates/_helpers.tpl
@@ -61,3 +61,11 @@ Inject extra environment populated by secrets, if populated
 {{- define "imagePullSecret" }}
 {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" (required "A valid .Values.imageCredentials.registry entry required" .Values.imageCredentials.registry) (printf "%s:%s" (required "A valid .Values.imageCredentials.username entry required" .Values.imageCredentials.username) (required "A valid .Values.imageCredentials.password entry required" .Values.imageCredentials.password) | b64enc) | b64enc }}
 {{- end }}
+
+{{- define "imageCredentials_name" }}
+{{- printf "%s" (required "A valid .Values.imageCredentials.name required" .Values.imageCredentials.name ) }}
+{{- end }}
+
+{{- define "serviceAccount" }}
+{{- printf "%s" (required "A valid .Values.serviceAccount.name required" .Values.serviceAccount.name ) }}
+{{- end }}

--- a/scanner/templates/image-pull-secret.yaml
+++ b/scanner/templates/image-pull-secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-registry-secret
+  name: {{ .Values.imageCredentials.name }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/scanner/templates/scanner-deployment.yaml
+++ b/scanner/templates/scanner-deployment.yaml
@@ -27,11 +27,7 @@ spec:
       securityContext:
 {{ toYaml . | indent 8 }}
       {{- end }}
-      {{- if .Values.aquaCluster}}
-      serviceAccount: {{ .Values.serviceAccount }}
-      {{- else }}
-      serviceAccount: {{ .Release.Namespace }}-sa
-      {{- end }}
+      serviceAccount: {{ .Values.serviceAccount.name }}
       containers:
       - name: scanner
         {{- with .Values.container_securityContext }}
@@ -93,8 +89,4 @@ spec:
       - name: docker-socket-mount
         hostPath:
           path: {{ .Values.dockerSock.path }}
-      {{- end }}
-      {{- if .Values.imageCredentials.create }}
-      imagePullSecrets:
-        - name: {{ .Values.imageCredentials.name }}
       {{- end }}

--- a/scanner/templates/service-account.yaml
+++ b/scanner/templates/service-account.yaml
@@ -1,13 +1,21 @@
-{{- if not .Values.aquaCluster }}
+{{- if not .Values.serviceAccount.name }}
+{{ template "serviceAccount" .}}
+{{- end }}
+{{- if .Values.serviceAccount.create }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Namespace }}-sa
+  name: {{ .Values.serviceAccount.name }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   namespace: {{ .Release.Namespace }}
+imagePullSecrets:
+{{- if not .Values.imageCredentials.name }}
+{{ template "imageCredentials_name" . }}
+{{- end }}
+- name: {{ .Values.imageCredentials.name }}
 {{- end }}

--- a/scanner/values.yaml
+++ b/scanner/values.yaml
@@ -22,7 +22,7 @@ server:
 
 image:
   repository: scanner
-  tag: "6.2.preview5"
+  tag: "6.2.preview6"
   pullPolicy: IfNotPresent
 
 logLevel:

--- a/scanner/values.yaml
+++ b/scanner/values.yaml
@@ -7,13 +7,13 @@ imageCredentials:
   username: ""
   password: ""
 
-aquaCluster: true   #Change it to false if deploying scanner on a different cluster(Not in Aqua deployed cluster)
-
 dockerSock:
   mount: # put true for mount docker socket.
   path: /var/run/docker.sock # pks - /var/vcap/data/sys/run/docker/docker.sock
 
-serviceAccount: "aqua-sa"
+serviceAccount:
+  create: false     #Change it to false if the cluster doesn't consists aqua service account
+  name: "aqua-sa"   #Mention the Service Account name, Default "aqua-sa"
 
 server:
   scheme: "http" #specify the schema for the server host URL, default it is http
@@ -29,6 +29,7 @@ logLevel:
 
 user: ""
 password: ""
+
 replicaCount: 1
 livenessProbe: {}
 readinessProbe: {}

--- a/server/README.md
+++ b/server/README.md
@@ -214,7 +214,7 @@ Parameter | Description | Default| Mandatory
 `db.persistence.size` |	Persistent Volume size | `30Gi`| `NO` 
 `db.persistence.storageClass` |	Persistent Volume Storage Class | `unset`| `NO` 
 `db.image.repository` | the docker image name to use | `database`| `NO` 
-`db.image.tag` | The image tag to use. | `6.2.preview5`| `NO` 
+`db.image.tag` | The image tag to use. | `6.2.preview6`| `NO` 
 `db.image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`| `NO` 
 `db.service.type` | k8s service type | `ClusterIP`| `NO` 
 `db.resources` |	Resource requests and limits | `{}`| `NO` 
@@ -225,7 +225,7 @@ Parameter | Description | Default| Mandatory
 `db.extraEnvironmentVars` | is a list of extra environment variables to set in the database deployments. | `{}`| `NO`
 `db.extraSecretEnvironmentVars` | is a list of extra environment variables to set in the database deployments, these variables take value from existing Secret objects. | `[]`| `NO`
 `gate.image.repository` | the docker image name to use | `gateway`| `NO` 
-`gate.image.tag` | The image tag to use. | `6.2.preview5`| `NO` 
+`gate.image.tag` | The image tag to use. | `6.2.preview6`| `NO` 
 `gate.image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`| `NO` 
 `gate.service.type` | k8s service type | `ClusterIP`| `NO` 
 `gate.service.annotations` |	service annotations	| `{}` | `NO`
@@ -242,7 +242,7 @@ Parameter | Description | Default| Mandatory
 `gate.extraEnvironmentVars` | is a list of extra environment variables to set in the gateway deployments. | `{}`| `NO`
 `gate.extraSecretEnvironmentVars` | is a list of extra environment variables to set in the gateway deployments, these variables take value from existing Secret objects. | `[]`| `NO`
 `web.image.repository` | the docker image name to use | `console`| `NO` 
-`web.image.tag` | The image tag to use. | `6.2.preview5`| `NO` 
+`web.image.tag` | The image tag to use. | `6.2.preview6`| `NO` 
 `web.image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`| `NO` 
 `web.service.type` | k8s service type | `LoadBalancer`| `NO` 
 `web.service.annotations` |	service annotations	| `{}`| `NO`

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -73,7 +73,7 @@ db:
     privileged: false
   image:
     repository: database
-    tag: "6.2.preview5"
+    tag: "6.2.preview6"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP
@@ -128,7 +128,7 @@ gate:
   logLevel:
   image:
     repository: gateway
-    tag: "6.2.preview5"
+    tag: "6.2.preview6"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP     #for OCP/OSD environments Can enable gateway to external by changing type to "LoadBalancer"
@@ -203,7 +203,7 @@ web:
   logLevel:
   image:
     repository: console
-    tag: "6.2.preview5"
+    tag: "6.2.preview6"
     pullPolicy: IfNotPresent
   service:
     type: LoadBalancer

--- a/tenant-manager/README.md
+++ b/tenant-manager/README.md
@@ -140,7 +140,7 @@ Parameter | Description | Default| Mandatory
 `db.persistence.size` |	Persistent volume size | `30Gi`| `NO` 
 `db.persistence.storageClass` |	Persistent volume storage class | `unset`| `NO` 
 `db.image.repository` | Docker image name to use | `database`| `NO` 
-`db.image.tag` | Image tag to use | `6.2.preview5`| `NO` 
+`db.image.tag` | Image tag to use | `6.2.preview6`| `NO` 
 `db.image.pullPolicy` | Kubernetes image pull policy | `IfNotPresent`| `NO` 
 `db.service.type` | Kubernetes service type | `ClusterIP`| `NO` 
 `db.resources` |	Resource requests and limits | `{}`| `NO` 
@@ -151,7 +151,7 @@ Parameter | Description | Default| Mandatory
 `db.extraEnvironmentVars` | List of extra environment variables to set in the database deployments | `{}`| `NO`
 `db.extraSecretEnvironmentVars` | List of extra environment variables to set in the database deployments; these variables take values from existing Secret objects | `[]`| `NO`
 `tenantmanager.image.repository` | Docker image name to use | `tenantmanager`| `NO` 
-`tenantmanager.image.tag` | Image tag to use | `6.2.preview5`| `NO` 
+`tenantmanager.image.tag` | Image tag to use | `6.2.preview6`| `NO` 
 `tenantmanager.image.pullPolicy` | Kubernetes image pull policy | `IfNotPresent`| `NO` 
 `tenantmanager.service.type` | Kubernetes service type | `LoadBalancer`| `NO` 
 `tenantmanager.service.annotations` |	Service annotations	| `{}`| `NO`

--- a/tenant-manager/values.yaml
+++ b/tenant-manager/values.yaml
@@ -55,7 +55,7 @@ db:
 
   image:
     repository: database
-    tag: "6.2.preview5"
+    tag: "6.2.preview6"
     pullPolicy: IfNotPresent
 
   service:
@@ -114,7 +114,7 @@ tenantmanager:
 
   image:
     repository: tenantmanager
-    tag: "6.2.preview5"
+    tag: "6.2.preview6"
     pullPolicy: IfNotPresent
 
   service:


### PR DESCRIPTION
1. Fixed KE imagepull secrets link with deployment, now attached to serviceaccount
2. Fixed scanner service account creation when it deployed in a cluster where aqua-sa doesn't exist.
3. Made imageCredentials.name variable as mandatory and throws Info message if its declaration fails in both Scanner and KE chart.
4. Adding preview6 image tag