### PR TITLE
6.0 | fixing scanner serviceaccount bug & KE imagesecrets bug

### DIFF
--- a/kube-enforcer/templates/_helpers.tpl
+++ b/kube-enforcer/templates/_helpers.tpl
@@ -50,3 +50,7 @@ Create chart name and version as used by the chart label.
 {{- define "certsSecret_name" }}
 {{- printf "%s" (required "A valid .Values.certsSecret.name required" .Values.certsSecret.name ) }}
 {{- end }}
+
+{{- define "imageCredentials_name" }}
+{{- printf "%s" (required "A valid .Values.imageCredentials.name required" .Values.imageCredentials.name ) }}
+{{- end }}

--- a/kube-enforcer/templates/kube-enforcer-deployment.yaml
+++ b/kube-enforcer/templates/kube-enforcer-deployment.yaml
@@ -124,8 +124,6 @@ spec:
         - name: "envoy-shared"
           emptyDir: {}
 {{- end }}
-      imagePullSecrets:
-        - name: {{ .Values.imageCredentials.name }}
   selector:
     matchLabels:
       app: {{ include "kube-enforcer.fullname" . }}

--- a/kube-enforcer/templates/service-account.yaml
+++ b/kube-enforcer/templates/service-account.yaml
@@ -9,4 +9,8 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   namespace: {{ .Values.namespace }}
-
+imagePullSecrets:
+{{- if not .Values.imageCredentials.name }}
+{{ template "imageCredentials_name" . }}
+{{- end }}
+- name: {{ .Values.imageCredentials.name }}

--- a/scanner/README.md
+++ b/scanner/README.md
@@ -72,7 +72,8 @@ Parameter | Description | Default| Mandatory
 `repositoryUriPrefix` | repository uri prefix for dockerhub set `docker.io` | `registry.aquasec.com`| `YES` 
 `dockerSocket.mount` | boolean parameter if to mount docker socket | `unset`| `NO` 
 `dockerSocket.path` | docker socket path | `/var/run/docker.sock`| `NO` 
-`serviceAccount` | k8s service account to use | `aqua-sa`| `YES` 
+`serviceAccount.create` | Enable to create serviceaccount if not exist in the k8s | `false`| `NO`
+`serviceAccount.name` | K8 service-account name either existing one or new name if create is enabled | `aqua-sa`  | `YES`
 `server.scheme` | scheme for server to connect | `http`| `NO`
 `server.serviceName` | service name for server to connect | `aqua-console-svc`| `YES` 
 `server.port` | service port for server to connect | `8080`| `YES` 

--- a/scanner/templates/_helpers.tpl
+++ b/scanner/templates/_helpers.tpl
@@ -61,3 +61,11 @@ Inject extra environment populated by secrets, if populated
 {{- define "imagePullSecret" }}
 {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" (required "A valid .Values.imageCredentials.registry entry required" .Values.imageCredentials.registry) (printf "%s:%s" (required "A valid .Values.imageCredentials.username entry required" .Values.imageCredentials.username) (required "A valid .Values.imageCredentials.password entry required" .Values.imageCredentials.password) | b64enc) | b64enc }}
 {{- end }}
+
+{{- define "imageCredentials_name" }}
+{{- printf "%s" (required "A valid .Values.imageCredentials.name required" .Values.imageCredentials.name ) }}
+{{- end }}
+
+{{- define "serviceAccount" }}
+{{- printf "%s" (required "A valid .Values.serviceAccount.name required" .Values.serviceAccount.name ) }}
+{{- end }}

--- a/scanner/templates/image-pull-secret.yaml
+++ b/scanner/templates/image-pull-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.imageCredentials.name }}
-    labels:
+  labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"

--- a/scanner/templates/image-pull-secret.yaml
+++ b/scanner/templates/image-pull-secret.yaml
@@ -3,8 +3,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-registry-secret
-  labels:
+  name: {{ .Values.imageCredentials.name }}
+    labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"

--- a/scanner/templates/scanner-deployment.yaml
+++ b/scanner/templates/scanner-deployment.yaml
@@ -27,11 +27,7 @@ spec:
       securityContext:
 {{ toYaml . | indent 8 }}
       {{- end }}
-      {{- if .Values.aquaCluster}}
-      serviceAccount: {{ .Values.serviceAccount }}
-      {{- else }}
-      serviceAccount: {{ .Release.Namespace }}-sa
-      {{- end }}
+      serviceAccount: {{ .Values.serviceAccount.name }}
       containers:
       - name: scanner
         {{- with .Values.container_securityContext }}
@@ -93,8 +89,4 @@ spec:
       - name: docker-socket-mount
         hostPath:
           path: {{ .Values.dockerSock.path }}
-      {{- end }}
-      {{- if .Values.imageCredentials.create }}
-      imagePullSecrets:
-        - name: {{ .Values.imageCredentials.name }}
       {{- end }}

--- a/scanner/templates/service-account.yaml
+++ b/scanner/templates/service-account.yaml
@@ -1,4 +1,7 @@
-{{- if not .Values.aquaCluster }}
+{{- if not .Values.serviceAccount.name }}
+{{ template "serviceAccount" .}}
+{{- end }}
+{{- if .Values.serviceAccount.create }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/scanner/values.yaml
+++ b/scanner/values.yaml
@@ -7,13 +7,13 @@ imageCredentials:
   username: ""
   password: ""
 
-aquaCluster: true   #Change it to false if deploying scanner on a different cluster(Not in Aqua deployed cluster)
-
 dockerSock:
   mount: # put true for mount docker socket.
   path: /var/run/docker.sock # pks - /var/vcap/data/sys/run/docker/docker.sock
 
-serviceAccount: "aqua-sa"
+serviceAccount:
+  create: false     #Change it to false if the cluster doesn't consists aqua service account
+  name: "aqua-sa"   #Mention the Service Account name, Default "aqua-sa"
 
 server:
   scheme: "http" #specify the schema for the server host URL, default it is http
@@ -29,6 +29,7 @@ logLevel:
 
 user: ""
 password: ""
+
 replicaCount: 1
 livenessProbe: {}
 readinessProbe: {}


### PR DESCRIPTION
1. Fixed KE imagepull secrets link with deployment, now attached to serviceaccount
2. Fixed scanner service account creation when it deployed in a cluster where aqua-sa doesn't exist.
3. Made imageCredentials.name variable as mandatory and throws Info message if its declaration fails in both Scanner and KE chart.