### PR TITLE
5.3 |  loadbalancerIP support for server chart services && scanner password from secret

### DIFF
--- a/scanner/README.md
+++ b/scanner/README.md
@@ -10,7 +10,10 @@ These are Helm charts for installation and maintenance of Aqua Container Securit
   - [Contents](#contents)
   - [Prerequisites](#prerequisites)
     - [Container Registry Credentials](#container-registry-credentials)
+    - [Scanner User Credentials](#scanner-user-credentials)
   - [Installing the Chart](#installing-the-chart)
+    - [Installing Aqua Scanner from Github Repo](#installing-aqua-scanner-from-github-repo)
+    - [Installing Aqua Scanner from Helm Private Repository](#installing-aqua-scanner-from-helm-private-repository)
   - [Configurable Variables](#configurable-variables)
     - [Scanner](#scanner)
   - [Issues and feedback](#issues-and-feedback)
@@ -20,6 +23,10 @@ These are Helm charts for installation and maintenance of Aqua Container Securit
 ### Container Registry Credentials
 
 [Link](../docs/imagepullsecret.md)
+
+### Scanner User Credentials
+
+Before installing scanner chart the recommendation is to create user with scanning permissions, [Link to documentations](https://docs.aquasec.com/docs/add-scanners#section-add-a-scanner-user)
 
 ## Installing the Chart
 Follow the steps in this section for production grade deployments. You can either clone aqua-helm git repo or you can add our helm private repository ([https://helm.aquasec.com](https://helm.aquasec.com))
@@ -82,6 +89,9 @@ Parameter | Description | Default| Mandatory
 `image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`| `NO` 
 `user` | scanner username | `unset`| `YES` 
 `password` | scanner password | `unset`| `YES` 
+`passwordSecret.enable` | change it to true for loading scanner password from secret | `false` | `YES` <br /> `If password is not declared`
+`passwordSecret.secretName` | secret name for the scanner password secret | `null` | `YES` <br /> `If password is not declared`
+`passwordSecret.secretKey` | secret key of the scanner password | `null` | `YES` <br /> `If password is not declared`
 `replicaCount` | replica count | `1`| `NO` 
 `resources` |	Resource requests and limits | `{}`| `NO` 
 `nodeSelector` |	Kubernetes node selector	| `{}`| `NO` 

--- a/scanner/templates/_helpers.tpl
+++ b/scanner/templates/_helpers.tpl
@@ -69,3 +69,8 @@ Inject extra environment populated by secrets, if populated
 {{- define "serviceAccount" }}
 {{- printf "%s" (required "A valid .Values.serviceAccount.name required" .Values.serviceAccount.name ) }}
 {{- end }}
+
+{{- define "scannerSecret" }}
+{{- printf "%s" (required "A valid .Values.passwordSecret.secretName required" .Values.passwordSecret.secretName ) }}
+{{- printf "%s" (required "A valid .Values.passwordSecret.secretKey required" .Values.passwordSecret.secretKey ) }}
+{{- end }}

--- a/scanner/templates/scanner-deployment.yaml
+++ b/scanner/templates/scanner-deployment.yaml
@@ -42,7 +42,11 @@ spec:
         - --user
         - "{{ required "Please specify a username associated with the Scanner role" .Values.user }}"
         - --password
+        {{- if .Values.passwordSecret.enable }}
+        - "$(SCANNER_PASSWORD)"
+        {{- else }}
         - "{{ required "Please specify a password for a user associated with the Scanner role" .Values.password }}"
+        {{- end }}
         - --host
         - "{{ .Values.server.scheme | default "http" }}://{{ .Values.server.serviceName }}:{{ .Values.server.port }}"
         env:
@@ -52,6 +56,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        {{- if .Values.passwordSecret.enable }}
+          {{- if and  (not .Values.passwordSecret.secretName) (not .Values.passwordSecret.secretKey) }}
+          {{- template "scannerSecret" . }}
+          {{- else }}
+        - name: SCANNER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.passwordSecret.secretName }}
+              key: {{ .Values.passwordSecret.secretKey }}
+          {{- end }}
+        {{- end }}
         {{- include "scanner.extraEnvironmentVars" .Values | nindent 8 }}
         {{- include "scanner.extraSecretEnvironmentVars" .Values | nindent 8 }}
         {{- if .Values.dockerSock.mount }}

--- a/scanner/values.yaml
+++ b/scanner/values.yaml
@@ -27,8 +27,13 @@ image:
 
 logLevel:
 
-user: ""
-password: ""
+user: ""          # user name for the scanner created in the console
+password: ""      # password for the scanner user you can also use "passwordSecret" below for loading password from secrets
+# Loading scanner password from secret
+passwordSecret:
+  enable: false   # change it to true for loading password from secrets
+  secretName: ""  # secret name for the scanner password secret
+  secretKey: ""   # secret key of the scanner password
 
 replicaCount: 1
 livenessProbe: {}

--- a/server/README.md
+++ b/server/README.md
@@ -307,6 +307,7 @@ Parameter | Description | Default| Mandatory
 `gate.image.tag` | The image tag to use. | `5.3`| `NO` 
 `gate.image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`| `NO` 
 `gate.service.type` | k8s service type | `ClusterIP`| `NO` 
+`gate.service.loadbalancerIP` | can specify loadBalancerIP address for aqua-web in AKS platform | `null` | `NO`
 `gate.service.annotations` |	service annotations	| `{}` | `NO`
 `gate.service.ports` | array of ports settings | `array`| `NO`
 `gate.publicIP` | gateway public ip | `aqua-gateway`| `NO`
@@ -327,7 +328,8 @@ Parameter | Description | Default| Mandatory
 `web.image.repository` | the docker image name to use | `console`| `NO` 
 `web.image.tag` | The image tag to use. | `5.3`| `NO` 
 `web.image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`| `NO` 
-`web.service.type` | k8s service type | `LoadBalancer`| `NO` 
+`web.service.type` | k8s service type | `LoadBalancer`| `NO`
+`web.service.loadbalancerIP` | can specify loadBalancerIP address for aqua-web in AKS platform | `null` | `NO`
 `web.service.annotations` |	service annotations	| `{}`| `NO`
 `web.service.ports` | array of ports settings | `array`| `NO`
 `web.replicaCount` | replica count | `1`| `NO`
@@ -354,6 +356,7 @@ Parameter | Description | Default| Mandatory
 `envoy.image.tag` | The image tag to use. | `v1.14.1`| `NO`
 `envoy.image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`| `NO`
 `envoy.service.type` | k8s service type | `LoadBalancer`| `NO`
+`envoy.service.loadbalancerIP` | can specify loadBalancerIP address for aqua-web in AKS platform | `null` | `NO`
 `envoy.service.ports` | array of ports settings | `array`| `NO`
 `envoy.certsSecretName` | tls certificates for envoy, **notice: required for current configuration in files envoy.yaml** | `nil`| `NO`
 `envoy.livenessProbe` | liveness probes configuration for envoy | `{}`| `NO`

--- a/server/templates/envoy-service.yaml
+++ b/server/templates/envoy-service.yaml
@@ -18,6 +18,9 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.envoy.service.type }}
+  {{- if eq .Values.platform "aks" }}
+  loadBalancerIP: {{ .Values.web.service.loadbalancerIP }}
+  {{- end }}
   selector:
     app: {{ .Release.Name }}-envoy
   ports:

--- a/server/templates/envoy-service.yaml
+++ b/server/templates/envoy-service.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   type: {{ .Values.envoy.service.type }}
   {{- if eq .Values.platform "aks" }}
-  loadBalancerIP: {{ .Values.web.service.loadbalancerIP }}
+  loadBalancerIP: {{ .Values.envoy.service.loadbalancerIP }}
   {{- end }}
   selector:
     app: {{ .Release.Name }}-envoy

--- a/server/templates/gate-service.yaml
+++ b/server/templates/gate-service.yaml
@@ -15,6 +15,9 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.gate.service.type }}
+  {{- if eq .Values.platform "aks" }}
+  loadBalancerIP: {{ .Values.web.service.loadbalancerIP }}
+  {{- end }}
   selector:
     app: {{ .Release.Name }}-gateway
   ports:

--- a/server/templates/gate-service.yaml
+++ b/server/templates/gate-service.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   type: {{ .Values.gate.service.type }}
   {{- if eq .Values.platform "aks" }}
-  loadBalancerIP: {{ .Values.web.service.loadbalancerIP }}
+  loadBalancerIP: {{ .Values.gate.service.loadbalancerIP }}
   {{- end }}
   selector:
     app: {{ .Release.Name }}-gateway

--- a/server/templates/web-service.yaml
+++ b/server/templates/web-service.yaml
@@ -14,6 +14,9 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.web.service.type }}
+  {{- if eq .Values.platform "aks" }}
+  loadBalancerIP: {{ .Values.web.service.loadbalancerIP }}
+  {{- end }}
   selector:
     app: {{ .Release.Name }}-console
   ports:

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -134,7 +134,8 @@ gate:
     tag: "5.3"
     pullPolicy: IfNotPresent
   service:
-    type: ClusterIP     #for OCP/OSD environments Can enable gateway to external by changing type to "LoadBalancer"
+    type: ClusterIP     # you can enable gateway to external by changing type to "LoadBalancer"
+    loadbalancerIP: "" # Specify loadBalancerIP address for aqua-web in AKS platform
     annotations: {}
     ports:
       - name: aqua-gate
@@ -211,6 +212,7 @@ web:
     pullPolicy: IfNotPresent
   service:
     type: LoadBalancer
+    loadbalancerIP: "" # Specify loadBalancerIP address for aqua-gateway in AKS platform
     annotations: {}
     ports:
       - name: aqua-web
@@ -302,6 +304,7 @@ envoy:
 
   service:
     type: LoadBalancer
+    loadbalancerIP: "" # Specify loadBalancerIP address for envoy in AKS platform
     annotations: {}
     ports:
     - name: https


### PR DESCRIPTION
1. Added loadbalancerIP support for server chart services for the AKS platform which fixes #142
2. Added support for loading scanner password from the secret, which fixes #118 #120
3. updated document with the new config added in values.yaml #119