### PR TITLE
6.0 | Server | Enhancement | Envoy config templated and TLS certs for listener and cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,15 @@ Refer to the Aqua Enterprise product documentation for the broader context: [Kub
 
 This repository includes the following charts; they can be deployed separately:
 
-| Chart | Description |
-|-|-|
-| [Server](server/) | Deploys the Console, Database, and Gateway components; optionally deploys the Scanner and Envoy components |
-| [Enforcer](enforcer/) | Deploys the Aqua Enforcer daemonset |
-| [Scanner](scanner/)  | Deploys the Aqua Scanner deployment |
-| [KubeEnforcer](kube-enforcer/)| Deploys the Aqua KubeEnforcer |
-| [QuickStart](aqua-quickstart)| Not for production use (see below). Deploys the Console, Database, Gateway, and KubeEnforcer components |
+| Chart | Description | Latest Chart Version |
+|-|-|-|
+| [Server](server/) | Deploys the Console, Database, and Gateway components; optionally deploys Envoy component | 6.0.3 |
+| [Enforcer](enforcer/) | Deploys the Aqua Enforcer daemonset | 6.0.3 |
+| [Scanner](scanner/)  | Deploys the Aqua Scanner deployment | 6.0.4 |
+| [KubeEnforcer](kube-enforcer/)| Deploys the Aqua KubeEnforcer | 6.0.3 |
+| [Gateway](gateway)| Deploys the Aqua Standalone Gateway | 6.0.1 |
+| [Tenant-Manager](tenant-manager/)| Deploys the Aqua Tenant Manager | 6.0.2 |
+| [QuickStart](aqua-quickstart/ )| Not for production use (see [below](#quick-start-deployment-not-for-production-purposes)). Deploys the Console, Database, Gateway and KubeEnforcer components | 6.0.1 |
 
 # Deployment instructions
 
@@ -82,14 +84,22 @@ aqua-helm/kube-enforcer   6.0.0               6.0                 A Helm chart f
 ### Deploy the Helm charts
 
 1. Create the `aqua` namespace.
-```bash
-$ kubectl create namespace aqua
-```
+    ```bash
+    $ kubectl create namespace aqua
+    ```
 2. Deploy the [**Server**](server/) chart.
 3. Deploy the [**Enforcer**](enforcer/) chart.
 4. Deploy the [**KubeEnforcer**](kube-enforcer/) chart.
 5. (Optional) Deploy the [**Scanner**](scanner/) chart.
 6. (For multi-cluster) Deploy the [**Gateway**](gateway/) chart.
+7. (Optional) Deploy the [**TenantManager**](tenant-manager/) chart.
+8. Access the Aqua UI in browser with {{ .Release.Name }}-console-svc service and port, to check the service details:
+      ```bash
+      $ kubectl get svc -n aqua
+      ```
+     * Example:
+       * http://< Console IP/DNS >:8080* (default access without SSL) or
+       * https://< Console IP/DNS >:443* (If SSL configured to console component in server chart)
 
 ### Troubleshooting
 

--- a/enforcer/CHANGELOG.md
+++ b/enforcer/CHANGELOG.md
@@ -9,4 +9,9 @@ Improvements:
 * Updated Readme
 
 Bugs:
-* Service Account naming error #[241](https://github.com/aquasecurity/aqua-helm/pull/241)
+* Service Account naming error [#241](https://github.com/aquasecurity/aqua-helm/pull/241)
+
+## 6.0.3 (May 24th, 2021)
+
+Improvements:
+* added simple way to add certificates for enforcer to connect gateway/envoy with TLS/mTLS and updated relevant Readme - [#267](https://github.com/aquasecurity/aqua-helm/pull/267)

--- a/enforcer/Chart.yaml
+++ b/enforcer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "6.0"
 description: A Helm chart for the Aqua Enforcer
 name: enforcer
-version: 6.0.2
+version: 6.0.3
 icon: https://avatars3.githubusercontent.com/u/12783832?s=200&v=4
 home: https://www.aquasec.com/
 maintainers:

--- a/scanner/CHANGELOG.md
+++ b/scanner/CHANGELOG.md
@@ -11,5 +11,12 @@ Improvements:
 ## 6.0.3 (May 12th, 2021)
 
 Bug Fixes:
-* Fixed Service Account creation bug #[264](https://github.com/aquasecurity/aqua-helm/pull/264)
+* Fixed Service Account creation bug [#264](https://github.com/aquasecurity/aqua-helm/pull/264)
 
+## 6.0.4 (May 24th, 2021)
+
+Bug Fixes:
+* fixed [#118](https://github.com/aquasecurity/aqua-helm/issues/118) [#119](https://github.com/aquasecurity/aqua-helm/issues/119) [#120](https://github.com/aquasecurity/aqua-helm/issues/120) issues by adding support to load scanner user password from secrets - [#270](https://github.com/aquasecurity/aqua-helm/pull/271)
+
+Improvements:
+* Updated Readme - [#270](https://github.com/aquasecurity/aqua-helm/pull/271)

--- a/scanner/Chart.yaml
+++ b/scanner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "6.0"
 description: A Helm chart for the Aqua Scanner CLI component
 name: scanner
-version: 6.0.3
+version: 6.0.4
 icon: https://avatars3.githubusercontent.com/u/12783832?s=200&v=4
 home: https://www.aquasec.com/
 maintainers:

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -7,5 +7,14 @@ Improvements:
 
 Improvements:
 * Updated Readme
-* Added Maintenance DB support #[245](https://github.com/aquasecurity/aqua-helm/pull/245)
-* added annotations support foe SA creation #[248](https://github.com/aquasecurity/aqua-helm/pull/248)
+* Added Maintenance DB support [#245](https://github.com/aquasecurity/aqua-helm/pull/245)
+* added annotations support foe SA creation [#248](https://github.com/aquasecurity/aqua-helm/pull/248)
+
+## 6.0.3 (May 24th, 2021)
+
+Bug Fixes:
+* Fixed LoadBalancerIP issue [#142](https://github.com/aquasecurity/aqua-helm/issues/142) for server chart in aks environment - [#270](https://github.com/aquasecurity/aqua-helm/pull/270)
+
+Improvements:
+* added simple way to add certificates to enable mTLS/SSL for server gateway components and updated relevant Readme - [#267](https://github.com/aquasecurity/aqua-helm/pull/267)
+* Updated Readme - [#272](https://github.com/aquasecurity/aqua-helm/pull/272)

--- a/server/Chart.yaml
+++ b/server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "6.0"
 description: A Helm chart for the Aqua Console components
 name: server
-version: 6.0.2
+version: 6.0.3
 icon: https://avatars3.githubusercontent.com/u/12783832?s=200&v=4
 home: https://www.aquasec.com/
 maintainers:

--- a/server/README.md
+++ b/server/README.md
@@ -91,26 +91,32 @@ $ helm upgrade --install --namespace aqua aqua aqua-helm/server --set imageCrede
       ```shell
       # Self-Signed Root CA (Optional)
       #####################################################################################
+      
       # Create Root Key
       # If you want a non password protected key just remove the -des3 option
       openssl genrsa -des3 -out rootCA.key 4096
+      
       # Create and self sign the Root Certificate
       openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 1024 -out rootCA.crt
+      
       #####################################################################################
       # Create a certificate
       #####################################################################################
+      
       # Create the certificate key
       openssl genrsa -out mydomain.com.key 2048
       # Create the signing (csr)
       openssl req -new -key mydomain.com.key -out mydomain.com.csr
       # Verify the csr content
       openssl req -in mydomain.com.csr -noout -text
+      
       #####################################################################################
       # Generate the certificate using the mydomain csr and key along with the CA Root key
       #####################################################################################
+
       openssl x509 -req -in mydomain.com.csr -CA rootCA.crt -CAkey rootCA.key -CAcreateserial -out mydomain.com.crt -days 500 -sha256
-      #####################################################################################
       
+      #####################################################################################
       # If you wish to use a Public CA like GoDaddy or LetsEncrypt please
       # submit the mydomain csr to the respective CA to generate mydomain crt
       ```
@@ -118,15 +124,30 @@ $ helm upgrade --install --namespace aqua aqua aqua-helm/server --set imageCrede
    2. Create TLS cert secret
    
       ```shell
-      # Please be notified that tls.key and tls.crt in the below command are default filenames
-      # and same as mydomain.com.key and mydomain.com.crt in the above openssl commands
-      # If tls.crt and tls.key filenames are changed then it should be changed in values.yaml envoy config
-      $ kubectl create secret tls aqua-lb-tls --key tls.key --cert tls.crt -n aqua
+      $ kubectl create secret generic aqua-lb-tls --from-file=mydomain.com.crt --from-file=mydomain.com.key --from-file=rootCA.crt -n aqua
       ```
    
-   3. Edit values.yaml file to include above secret name at `envoy.certsSecretName`
+   3. Edit the values.yaml file to include above secret 
+   ```
+       TLS:
+         listener:
+            secretName: "aqua-lb-tls"
+            publicKey_fileName: "mydomain.com.crt"
+            privateKey_fileName: "mydomain.com.key"
+            rootCA_fileName: "rootCA.crt"
+   ```
    
-   4. Also set `envoy.enabled` to `true`
+   4. [Optional] If Gateway requires client certificate authentication edit the values.yaml to include those secrets as well:
+   ```
+       TLS:
+         ...
+         cluster:
+            enabled: true
+            secretName: "aqua-lb-tls-custer"
+            publicKey_fileName: "envoy.crt"
+            privateKey_fileName: "envoy.key"
+            rootCA_fileName: "rootCA.crt"
+   ```
    
    5. For more customizations please refer to [***Configurable Variables***](#configure-variables)
    
@@ -182,14 +203,17 @@ $ helm upgrade --install --namespace aqua aqua aqua-helm/server --set imageCrede
       ```shell
       # Self-Signed Root CA (Optional)
       #####################################################################################
+      
       # Create Root Key
       # If you want a non password protected key just remove the -des3 option
       openssl genrsa -des3 -out rootCA.key 4096
       # Create and self sign the Root Certificate
       openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 1024 -out rootCA.crt
+      
       #####################################################################################
       # Create a aqua server and gateway certificate
       #####################################################################################
+      
       # Create the server certificate key
       openssl genrsa -out aqua_web_mydomain.com.key 2048
       # Create the gateway certificate key
@@ -201,14 +225,16 @@ $ helm upgrade --install --namespace aqua aqua aqua-helm/server --set imageCrede
       # Verify the csr content
       openssl req -in aqua_web_mydomain.com.csr -noout -text
       openssl req -in aqua_gateway_mydomain.com.csr -noout -text
+      
       #####################################################################################
       # Generate the certificate using the mydomain csr and key along with the CA Root key
       # for server and gateway
       #####################################################################################
+      
       openssl x509 -req -in aqua_web_mydomain.com.csr -CA rootCA.crt -CAkey rootCA.key -CAcreateserial -out aqua_web_mydomain.com.crt -days 500 -sha256
       openssl x509 -req -in aqua_gateway_mydomain.com.csr -CA rootCA.crt -CAkey rootCA.key -CAcreateserial -out aqua_gateway_mydomain.com.crt -days 500 -sha256
+      
       #####################################################################################
-
       # If you wish to use a Public CA like GoDaddy or LetsEncrypt please
       # submit the mydomain csr to the respective CA to generate mydomain crt
       ```
@@ -216,8 +242,8 @@ $ helm upgrade --install --namespace aqua aqua aqua-helm/server --set imageCrede
   2.  Create Kubernetes secrets for server and gateway components using the generated SSL certificates.
 
          ```shell
-         ## Example:
-         ## Change < certificate filenames > respectively
+         # Example:
+         # Change < certificate filenames > respectively
          $ kubectl create secret generic aqua-web-certs --from-file <aqua_web_private.key> --from-file <aqua_web_public.crt> --from-file <rootCA.crt> -n aqua
 
          $ kubectl create secret generic aqua-gateway-certs --from-file <aqua_gateway_private.key> --from-file <aqua_gateway_public.crt> --from-file <rootCA.crt> -n aqua
@@ -358,7 +384,15 @@ Parameter | Description | Default| Mandatory
 `envoy.service.type` | k8s service type | `LoadBalancer`| `NO`
 `envoy.service.loadbalancerIP` | can specify loadBalancerIP address for aqua-web in AKS platform | `null` | `NO`
 `envoy.service.ports` | array of ports settings | `array`| `NO`
-`envoy.certsSecretName` | tls certificates for envoy, **notice: required for current configuration in files envoy.yaml** | `nil`| `NO`
+`envoy.TLS.listener.secretName` | certificates secret name | `nil` | `YES` <br /> `if envoy.enabled is set to true`
+`envoy.TLS.listener.publicKey_fileName` | filename of the public key eg: aqua-lb.fqdn.crt | `nil`  |  `YES` <br /> `if envoy.enabled is set to true`
+`envoy.TLS.listener.privateKey_fileName`   | filename of the private key eg: aqua-lb.fqdn.key | `nil`  |  `YES` <br /> `if envoy.enabled is set to true`
+`envoy.TLS.listener.rootCA_fileName` |  filename of the rootCA, if using self-signed certificates eg: rootCA.crt | `nil`  |  `NO`
+`envoy.TLS.cluster.enabled` | If require secure channel communication between Envoy and Gateway | `false` | `NO`
+`envoy.TLS.cluster.secretName` | certificates secret name | `nil` | `NO`
+`envoy.TLS.cluster.publicKey_fileName` | filename of the public key eg: aqua-lb.crt | `nil`  |  `NO`
+`envoy.TLS.cluster.privateKey_fileName`   | filename of the private key eg: aqua-lb.key | `nil`  |  `NO`
+`envoy.TLS.cluster.rootCA_fileName` |  filename of the rootCA, if using self-signed certificates eg: rootCA.crt | `nil`  |  `NO`
 `envoy.livenessProbe` | liveness probes configuration for envoy | `{}`| `NO`
 `envoy.readinessProbe` | readiness probes configuration for envoy | `{}`| `NO`
 `envoy.resources` |	Resource requests and limits | `{}`| `NO`

--- a/server/conf/envoy.yaml.tpl
+++ b/server/conf/envoy.yaml.tpl
@@ -1,0 +1,107 @@
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 8443
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stream_idle_timeout: 0s
+          drain_timeout: 20s
+          access_log:
+          - name: envoy.access_loggers.file
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+              path: "/dev/stdout"
+          codec_type: AUTO
+          stat_prefix: ingress_https
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: https
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: aqua-gateway-svc
+                  timeout: 0s
+          http_filters:
+          - name: envoy.filters.http.health_check
+            typed_config:
+              "@type": type.googleapis.com/envoy.config.filter.http.health_check.v2.HealthCheck
+              pass_through_mode: false
+              headers:
+              - name: ":path"
+                exact_match: "/healthz"
+              - name: "x-envoy-livenessprobe"
+                exact_match: "healthz"
+          - name: envoy.filters.http.router
+            typed_config: {}
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          common_tls_context:
+            {{- if .Values.envoy.TLS.listener.rootCA_fileName }}
+            validation_context:
+              trusted_ca:
+                filename: "/etc/ssl/envoy/listener/{{ .Values.envoy.TLS.listener.rootCA_fileName }}"
+            {{- end }}
+            alpn_protocols: "h2,http/1.1"
+            tls_certificates:
+            - certificate_chain:
+                filename: "/etc/ssl/envoy/listener/{{ .Values.envoy.TLS.listener.publicKey_fileName }}"
+              private_key:
+                filename: "/etc/ssl/envoy/listener/{{ .Values.envoy.TLS.listener.privateKey_fileName }}"
+  clusters:
+  - name: aqua-gateway-svc
+    connect_timeout: 180s
+    type: STRICT_DNS
+    dns_lookup_family: V4_ONLY
+    lb_policy: ROUND_ROBIN
+    http2_protocol_options:
+      hpack_table_size: 4294967
+      max_concurrent_streams: 2147483647
+    circuit_breakers:
+        thresholds:
+            max_pending_requests: 2147483647
+            max_requests: 2147483647
+    load_assignment:
+      cluster_name: aqua-gateway-svc
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: {{ .Release.Name }}-gateway-headless-svc.{{ .Release.Namespace }}.svc.cluster.local
+                port_value: 8443
+    {{- if .Values.envoy.TLS.cluster.enabled }}
+    transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+            "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+            sni: {{ .Release.Name }}-gateway-svc
+            common_tls_context:
+              {{- if .Values.envoy.TLS.cluster.rootCA_fileName }}
+              validation_context:
+                trusted_ca:
+                  filename: "/etc/ssl/envoy/cluster/{{ .Values.envoy.TLS.cluster.rootCA_fileName }}"
+              {{- end }}
+              alpn_protocols: "h2,http/1.1"
+              tls_certificates:
+              - certificate_chain:
+                  filename: "/etc/ssl/envoy/cluster/{{ .Values.envoy.TLS.cluster.publicKey_fileName }}"
+                private_key:
+                  filename: "/etc/ssl/envoy/cluster/{{ .Values.envoy.TLS.cluster.privateKey_fileName }}"
+    {{- end }}
+admin:
+  access_log_path: "/dev/stdout"
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 8090

--- a/server/templates/envoy-config.yaml
+++ b/server/templates/envoy-config.yaml
@@ -9,9 +9,14 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-{{- range $key, $value := .Values.envoy.files }}
+{{- if gt (len .Values.envoy.custom_envoy_files ) 0 }}
+{{- range $key, $value := .Values.envoy.custom_envoy_files }}
   {{ $key }}: |-
 {{ $valueWithDefault := default "" $value -}}
 {{ tpl $valueWithDefault $ | indent 4 }}
 {{- end -}}
+{{- else }}
+  envoy.yaml: |
+{{ tpl (.Files.Get "conf/envoy.yaml.tpl") . | indent 4}}
+{{- end }}
 {{- end }}

--- a/server/templates/envoy-deployment.yaml
+++ b/server/templates/envoy-deployment.yaml
@@ -43,9 +43,11 @@ spec:
         volumeMounts:
         - mountPath: /etc/envoy
           name: config
-        {{ if .Values.envoy.certsSecretName }}
-        - mountPath: /etc/ssl/envoy
-          name: certs
+        - mountPath: /etc/ssl/envoy/listener
+          name: listener-certs
+        {{ if .Values.envoy.TLS.cluster.enabled }}
+        - mountPath: /etc/ssl/envoy/cluster
+          name: cluster-certs
         {{- end }}
 {{- with .Values.envoy.livenessProbe }}
         livenessProbe:
@@ -76,10 +78,14 @@ spec:
           defaultMode: 420
           name: {{ .Release.Name }}-envoy-conf
         name: config
-      {{ if .Values.envoy.certsSecretName }}
-      - name: certs
+      - name: listener-certs
         secret:
           defaultMode: 420
-          secretName: {{ .Values.envoy.certsSecretName }}
+          secretName: {{ .Values.envoy.TLS.listener.secretName }}
+      {{ if .Values.envoy.TLS.cluster.enabled }}
+      - name: cluster-certs
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.envoy.TLS.cluster.secretName }}
       {{- end }}
 {{- end }}

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -314,7 +314,20 @@ envoy:
       nodePort:
       protocol: TCP
 
-  certsSecretName: ""
+  # Enabling Envoy requires the use of TLS certificates for the listener section, while the cluster TLS section is optional and to be enabled if TLS is in use for gate and web.
+  # Find the instructions in the readme for help with generating the required certificates.
+  TLS:
+    listener:
+      secretName: "aqua-lb-tls"         # provide secret name containing the certificates
+      publicKey_fileName: ""            # provide filename of the public key in the secret eg: aqua-lb.fqdn.crt
+      privateKey_fileName: ""           # provide filename of the private key in the secret eg: aqua-lb.fqdn.key
+      rootCA_fileName: ""               # optional: use this field if using a custom CA or chain
+    cluster:
+      enabled: false                    # true to enable secure communication between Aqua Envoy and Gateways
+      secretName: "aqua-lb-tls-custer"  # provide secret name containing the certificates
+      publicKey_fileName: ""            # provide filename of the public key in the secret eg: aqua-lb.crt
+      privateKey_fileName: ""           # provide filename of the private key in the secret eg: aqua-lb.key
+      rootCA_fileName: ""               # optional: use this field if using a custom CA or chain
 
   livenessProbe:
     failureThreshold: 3
@@ -356,96 +369,94 @@ envoy:
   affinity: {}
   securityContext: {}
 
-  files:
-    ## refs:
-    ## - https://www.envoyproxy.io/docs/envoy/latest/start/start#quick-start-to-run-simple-example
-    ## - https://raw.githubusercontent.com/envoyproxy/envoy/master/configs/google_com_proxy.v2.yaml
-    envoy.yaml: |
-      static_resources:
-        listeners:
-        - address:
-            socket_address:
-              address: 0.0.0.0
-              port_value: 8443
-          filter_chains:
-          - filters:
-            - name: envoy.filters.network.http_connection_manager
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                stream_idle_timeout: 0s
-                drain_timeout: 20s
-                access_log:
-                - name: envoy.access_loggers.file
-                  typed_config:
-                    "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                    path: "/dev/stdout"
-                codec_type: AUTO
-                stat_prefix: ingress_https
-                route_config:
-                  name: local_route
-                  virtual_hosts:
-                  - name: https
-                    domains:
-                    - "*"
-                    routes:
-                    - match:
-                        prefix: "/"
-                      route:
-                        cluster: aqua-gateway-svc
-                        timeout: 0s
-                http_filters:
-                - name: envoy.filters.http.health_check
-                  typed_config:
-                    "@type": type.googleapis.com/envoy.config.filter.http.health_check.v2.HealthCheck
-                    pass_through_mode: false
-                    headers:
-                    - name: ":path"
-                      exact_match: "/healthz"
-                    - name: "x-envoy-livenessprobe"
-                      exact_match: "healthz"
-                - name: envoy.filters.http.router
-                  typed_config: {}
-            transport_socket:
-              name: envoy.transport_sockets.tls
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
-                common_tls_context:
-                  alpn_protocols: "h2,http/1.1"
-                  tls_certificates:
-                  - certificate_chain:
-                      filename: "/etc/ssl/envoy/tls.crt"
-                    private_key:
-                      filename: "/etc/ssl/envoy/tls.key"
-        clusters:
-        - name: aqua-gateway-svc
-          connect_timeout: 180s
-          type: STRICT_DNS
-          dns_lookup_family: V4_ONLY
-          lb_policy: ROUND_ROBIN
-          http2_protocol_options:
-            hpack_table_size: 4294967
-            max_concurrent_streams: 2147483647
-          circuit_breakers:
-              thresholds:
-                  max_pending_requests: 2147483647
-                  max_requests: 2147483647
-          load_assignment:
-            cluster_name: aqua-gateway-svc
-            endpoints:
-            - lb_endpoints:
-              - endpoint:
-                  address:
-                    socket_address:
-                      address: {{ .Release.Name }}-gateway-headless-svc.{{ .Release.Namespace }}.svc.cluster.local
-                      port_value: 8443
-          transport_socket:
-              name: envoy.transport_sockets.tls
-              typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-                  sni: aqua-gateway-svc
-      admin:
-        access_log_path: "/dev/stdout"
-        address:
-          socket_address:
-            address: 127.0.0.1
-            port_value: 8090
+  ## Enabling this will replace any templated envoy configuration with the list of files passed below
+  custom_envoy_files: {}
+    # envoy.yaml: |
+    #   static_resources:
+    #     listeners:
+    #     - address:
+    #         socket_address:
+    #           address: 0.0.0.0
+    #           port_value: 8443
+    #       filter_chains:
+    #       - filters:
+    #         - name: envoy.filters.network.http_connection_manager
+    #           typed_config:
+    #             "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+    #             stream_idle_timeout: 0s
+    #             drain_timeout: 20s
+    #             access_log:
+    #             - name: envoy.access_loggers.file
+    #               typed_config:
+    #                 "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+    #                 path: "/dev/stdout"
+    #             codec_type: AUTO
+    #             stat_prefix: ingress_https
+    #             route_config:
+    #               name: local_route
+    #               virtual_hosts:
+    #               - name: https
+    #                 domains:
+    #                 - "*"
+    #                 routes:
+    #                 - match:
+    #                     prefix: "/"
+    #                   route:
+    #                     cluster: aqua-gateway-svc
+    #                     timeout: 0s
+    #             http_filters:
+    #             - name: envoy.filters.http.health_check
+    #               typed_config:
+    #                 "@type": type.googleapis.com/envoy.config.filter.http.health_check.v2.HealthCheck
+    #                 pass_through_mode: false
+    #                 headers:
+    #                 - name: ":path"
+    #                   exact_match: "/healthz"
+    #                 - name: "x-envoy-livenessprobe"
+    #                   exact_match: "healthz"
+    #             - name: envoy.filters.http.router
+    #               typed_config: {}
+    #         transport_socket:
+    #           name: envoy.transport_sockets.tls
+    #           typed_config:
+    #             "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+    #             common_tls_context:
+    #               alpn_protocols: "h2,http/1.1"
+    #               tls_certificates:
+    #               - certificate_chain:
+    #                   filename: "/etc/ssl/envoy/tls.crt"
+    #                 private_key:
+    #                   filename: "/etc/ssl/envoy/tls.key"
+    #     clusters:
+    #     - name: aqua-gateway-svc
+    #       connect_timeout: 180s
+    #       type: STRICT_DNS
+    #       dns_lookup_family: V4_ONLY
+    #       lb_policy: ROUND_ROBIN
+    #       http2_protocol_options:
+    #         hpack_table_size: 4294967
+    #         max_concurrent_streams: 2147483647
+    #       circuit_breakers:
+    #           thresholds:
+    #               max_pending_requests: 2147483647
+    #               max_requests: 2147483647
+    #       load_assignment:
+    #         cluster_name: aqua-gateway-svc
+    #         endpoints:
+    #         - lb_endpoints:
+    #           - endpoint:
+    #               address:
+    #                 socket_address:
+    #                   address: {{ .Release.Name }}-gateway-headless-svc.{{ .Release.Namespace }}.svc.cluster.local
+    #                   port_value: 8443
+    #       transport_socket:
+    #           name: envoy.transport_sockets.tls
+    #           typed_config:
+    #               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+    #               sni: aqua-gateway-svc
+    #   admin:
+    #     access_log_path: "/dev/stdout"
+    #     address:
+    #       socket_address:
+    #         address: 127.0.0.1
+    #         port_value: 8090


### PR DESCRIPTION
This PR proposes the following 2 changes:

- Envoy configuration is templated and the user can easily customise it using the Helm values
- Custom TLS certificates can be passed for both Envoy upstream and downstream communications (more about this below)

## Current Configuration
Currently the chart offers one option to pass TLS secrest to Envoy which is the following:

`certsSecretName: ""`

The problems with this are:

- the certificates names are hard-coded into the envoy configuration forcing the client to rename the files;
- there is no explicit way to pass a custom rootCA;
- this certicates only apply to the listener interface (which is the one that the Aqua Enforcers will connect to) but there is no option to pass certificates for client mTLS authentication from Envoy to the GW. If a user enables the other TLS sections in the chart for `web` and `gate`, Envoy will stop working unless the configuration is manually edited.

## Proposal
With this PR I'm proposing to:

- use a templated Envoy configuration which can be easily customised using the Helm values, hiding all the complexity
- allow the pro user pass advanced custom Envoy files
- replace the `certSecretName` with a TLS section similar to `gate` and `web` allowing different certificates for listener and cluster communication
- allow the user to pass optional custom rootCA files for either listener or cluster

```
  TLS:
    listener:
      secretName: "aqua-lb-tls"
      publicKey_fileName: ""
      privateKey_fileName: ""
      rootCA_fileName: ""
    cluster:
      enabled: false
      secretName: "aqua-lb-tls-custer"
      publicKey_fileName: ""
      privateKey_fileName: ""
      rootCA_fileName: ""
```

This way the user has full control over TLS communication from Enforcers and to GW without having to edit a single line of the Envoy configuration.