### PR TITLE
5.3 | Server | Fix | Disabling DB persistence doesn't work

### DIFF
--- a/server/templates/db-deployment.yaml
+++ b/server/templates/db-deployment.yaml
@@ -49,8 +49,10 @@ spec:
         image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.db.image.repository }}:{{ .Values.db.image.tag }}"
         command: [ "sh", "-c", "[ -f $PGDATA/server.key ] && chmod 600 $PGDATA/server.key || echo 'OK' " ]
         volumeMounts:
+        {{- if .Values.db.persistence.enabled }}
         - mountPath: /var/lib/postgresql/data
           name: postgres-database
+        {{- end }}
       containers:
       - name: db
         {{- with .Values.db.container_securityContext }}
@@ -80,8 +82,10 @@ spec:
         {{- include "server.extraEnvironmentVars" .Values.db | nindent 8 }}
         {{- include "server.extraSecretEnvironmentVars" .Values.db | nindent 8 }}
         volumeMounts:
+        {{- if .Values.db.persistence.enabled }}
         - mountPath: /var/lib/postgresql/data
           name: postgres-database
+        {{- end }}
         ports:
         - containerPort: 5432
           protocol: TCP
@@ -108,9 +112,11 @@ spec:
 {{ toYaml .Values.db.tolerations | indent 6 }}
       {{- end }}
       volumes:
+      {{- if .Values.db.persistence.enabled }}
       - name: postgres-database
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-database-pvc
+      {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -161,8 +167,10 @@ spec:
         image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.db.image.repository }}:{{ .Values.db.image.tag }}"
         command: [ "sh", "-c", "[ -f $PGDATA/server.key ] && chmod 600 $PGDATA/server.key || echo 'OK' " ]
         volumeMounts:
+        {{- if .Values.db.persistence.enabled }}
         - mountPath: /var/lib/postgresql/data
           name: postgres-audit-database
+        {{- end }}
       containers:
       - name: auditdb
         {{- with .Values.db.container_securityContext }}
@@ -192,8 +200,10 @@ spec:
         {{- include "server.extraEnvironmentVars" .Values.db | nindent 8 }}
         {{- include "server.extraSecretEnvironmentVars" .Values.db | nindent 8 }}
         volumeMounts:
+        {{- if .Values.db.persistence.enabled }}
         - mountPath: /var/lib/postgresql/data
           name: postgres-audit-database
+        {{- end }}
         ports:
         - containerPort: 5432
           protocol: TCP


### PR DESCRIPTION
This value is available in the chart:

```
db:
  persistence:
    enabled: true
```

The problem is that setting this to false only disable the creation of the PVCs but the DB deployments are still trying to mount the PVC resulting in pending pods.

This value is useful for lab and development purposes where you don't want (or can't have) persistence. Therefore should be kept and fixed. Proposing the fix in this PR.