### PR TITLE
6.0 | server | enhancement | adding support for k3s and gaintswarm platform

### DIFF
--- a/kube-enforcer/templates/NOTES.txt
+++ b/kube-enforcer/templates/NOTES.txt
@@ -1,0 +1,9 @@
+
+Thank you for installing Aqua Security KubeEnforcer.
+
+Now that you have deployed Aqua Enforcer, you should look over the docs on using: 
+
+https://docs.aquasec.com/docs
+
+
+Your release is named {{ .Release.Name }}.

--- a/scanner/README.md
+++ b/scanner/README.md
@@ -89,9 +89,10 @@ Parameter | Description | Default| Mandatory
 `image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`| `NO` 
 `user` | scanner username | `unset`| `YES` 
 `password` | scanner password | `unset`| `YES` 
-`passwordSecret.enable` | change it to true for loading scanner password from secret | `false` | `YES` <br /> `If password is not declared`
-`passwordSecret.secretName` | secret name for the scanner password secret | `null` | `YES` <br /> `If password is not declared`
-`passwordSecret.secretKey` | secret key of the scanner password | `null` | `YES` <br /> `If password is not declared`
+`scannerUserSecret.enable` | change it to true for loading scanner user, scanner password from secret | `false` | `YES` <br /> `If password is not declared`
+`scannerUserSecret.secretName` | secret name for the scanner user, scanner password secret | `null` | `YES` <br /> `If password is not declared`
+`scannerUserSecret.userKey` | secret key of the scanner user | `null` | `YES` <br /> `If password is not declared`
+`scannerUserSecret.passwordKey` | secret key of the scanner password | `null` | `YES` <br /> `If password is not declared`
 `replicaCount` | replica count | `1`| `NO` 
 `resources` |	Resource requests and limits | `{}`| `NO` 
 `nodeSelector` |	Kubernetes node selector	| `{}`| `NO` 

--- a/scanner/templates/_helpers.tpl
+++ b/scanner/templates/_helpers.tpl
@@ -71,6 +71,7 @@ Inject extra environment populated by secrets, if populated
 {{- end }}
 
 {{- define "scannerSecret" }}
-{{- printf "%s" (required "A valid .Values.passwordSecret.secretName required" .Values.passwordSecret.secretName ) }}
-{{- printf "%s" (required "A valid .Values.passwordSecret.secretKey required" .Values.passwordSecret.secretKey ) }}
+{{- printf "%s" (required "A valid .Values.scannerUserSecret.secretName required" .Values.scannerUserSecret.secretName ) }}
+{{- printf "%s" (required "A valid .Values.scannerUserSecret.userKey required" .Values.scannerUserSecret.userKey ) }}
+{{- printf "%s" (required "A valid .Values.scannerUserSecret.passwordKey required" .Values.scannerUserSecret.passwordKey ) }}
 {{- end }}

--- a/scanner/templates/scanner-deployment.yaml
+++ b/scanner/templates/scanner-deployment.yaml
@@ -27,7 +27,11 @@ spec:
       securityContext:
 {{ toYaml . | indent 8 }}
       {{- end }}
+      {{- if not .Values.serviceAccount}}
+      serviceAccount: {{ .Release.Name }}-sa
+      {{- else }}
       serviceAccount: {{ .Values.serviceAccount.name }}
+      {{- end }}
       containers:
       - name: scanner
         {{- with .Values.container_securityContext }}
@@ -38,14 +42,18 @@ spec:
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         args:
         - daemon
-        - --direct-cc 
+        - --direct-cc
         - --user
-        - "{{ required "Please specify a username associated with the Scanner role!" .Values.user }}"
+        {{- if .Values.scannerUserSecret.enable }}
+        - "$(SCANNER_USER)"
+        {{- else }}
+        - "{{ required "Please specify a username associated with the Scanner role" .Values.user }}"
+        {{- end }}
         - --password
-        {{- if .Values.passwordSecret.enable }}
+        {{- if .Values.scannerUserSecret.enable }}
         - "$(SCANNER_PASSWORD)"
         {{- else }}
-        - "{{ required "Please specify a password for a user associated with the Scanner role!" .Values.password }}"
+        - "{{ required "Please specify a password for a user associated with the Scanner role" .Values.password }}"
         {{- end }}
         - --host
         - "{{ .Values.server.scheme | default "http" }}://{{ .Values.server.serviceName }}:{{ .Values.server.port }}"
@@ -56,15 +64,20 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        {{- if .Values.passwordSecret.enable }}
-          {{- if and  (not .Values.passwordSecret.secretName) (not .Values.passwordSecret.secretKey) }}
+        {{- if .Values.scannerUserSecret.enable }}
+          {{- if or  (not .Values.scannerUserSecret.secretName) (not .Values.scannerUserSecret.passwordKey) (not .Values.scannerUserSecret.userKey) }}
           {{- template "scannerSecret" . }}
           {{- else }}
         - name: SCANNER_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.passwordSecret.secretName }}
-              key: {{ .Values.passwordSecret.secretKey }}
+              name: {{ .Values.scannerUserSecret.secretName }}
+              key: {{ .Values.scannerUserSecret.passwordKey }}
+        - name: SCANNER_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.scannerUserSecret.secretName }}
+              key: {{ .Values.scannerUserSecret.userKey }}
           {{- end }}
         {{- end }}
         {{- include "scanner.extraEnvironmentVars" .Values | nindent 8 }}

--- a/scanner/values.yaml
+++ b/scanner/values.yaml
@@ -29,11 +29,13 @@ logLevel:
 
 user: ""          # user name for the scanner created in the console
 password: ""      # password for the scanner user you can also use "passwordSecret" below for loading password from secrets
-# Loading scanner password from secret
-passwordSecret:
+
+# Loading scanner user & password from secret
+scannerUserSecret:
   enable: false   # change it to true for loading password from secrets
   secretName: ""  # secret name for the scanner password secret
-  secretKey: ""   # secret key of the scanner password
+  userKey: ""   # secret key of the scanner user
+  passwordKey: "" # secret key of the scanner password
 
 replicaCount: 1
 livenessProbe: {}

--- a/server/README.md
+++ b/server/README.md
@@ -277,7 +277,7 @@ Parameter | Description | Default| Mandatory
 `imageCredentials.registry` | set the registry url for dockerhub set `index.docker.io/v1/` | `registry.aquasec.com`| `YES`
 `imageCredentials.username` | Your Docker registry (DockerHub, etc.) username | `aqua-registry-secret`| `YES`
 `imageCredentials.password` | Your Docker registry (DockerHub, etc.) password | `unset`| `YES`
-`platform` | Orchestration platform name (Allowed values are aks, eks, gke, openshift, tkg, tkgi, k8s, rancher) | `unset` | `YES`
+`platform` | Orchestration platform name (Allowed values are aks, eks, gke, openshift, tkg, tkgi, k8s, rancher, gs, k3s) | `unset` | `YES`
 `openshift_route.create` | to create openshift routes for web and gateway | `false` | `NO`
 `rbac.enabled` | if to create rbac configuration for aqua | `true`| `YES`
 `rbac.privileged` | determines if any container in a pod can enable privileged mode. | `true`| `NO`

--- a/server/conf/envoy.yaml.tpl
+++ b/server/conf/envoy.yaml.tpl
@@ -78,14 +78,18 @@ static_resources:
         - endpoint:
             address:
               socket_address:
+                {{- if eq .Values.platform "gs" }}
+                address: {{ .Release.Name }}-gateway-headless-svc.{{ .Release.Namespace }}
+                {{- else }}
                 address: {{ .Release.Name }}-gateway-headless-svc.{{ .Release.Namespace }}.svc.cluster.local
+                {{- end }}
                 port_value: 8443
-    {{- if .Values.envoy.TLS.cluster.enabled }}
     transport_socket:
         name: envoy.transport_sockets.tls
         typed_config:
             "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
             sni: {{ .Release.Name }}-gateway-svc
+              {{- if .Values.envoy.TLS.cluster.enabled }}
             common_tls_context:
               {{- if .Values.envoy.TLS.cluster.rootCA_fileName }}
               validation_context:

--- a/server/templates/envoy-service.yaml
+++ b/server/templates/envoy-service.yaml
@@ -24,6 +24,19 @@ spec:
   selector:
     app: {{ .Release.Name }}-envoy
   ports:
+  {{- if eq .Values.platform "k3s"}}
+  {{- range $port := .Values.envoy.service.k3sPorts }}
+    - name: {{ $port.name }}
+      port: {{ $port.port }}
+      targetPort: {{ $port.targetPort }}
+      {{- if $port.nodePort }}
+      nodePort: {{ $port.nodePort }}
+      {{- end }}
+      {{- if $port.protocol }}
+      protocol: {{ $port.protocol }}
+      {{- end }}
+  {{- end }}
+  {{- else }}
   {{- range $port := .Values.envoy.service.ports }}
     - name: {{ $port.name }}
       port: {{ $port.port }}
@@ -36,4 +49,5 @@ spec:
       {{- end }}
   {{- end }}
 
+{{- end }}
 {{- end }}

--- a/server/templates/gate-deployment.yaml
+++ b/server/templates/gate-deployment.yaml
@@ -39,7 +39,11 @@ spec:
         - name: SCALOCK_LOG_LEVEL
           value: {{ .Values.gate.logLevel | default "INFO" }}
         - name: AQUA_CONSOLE_SECURE_ADDRESS
+        {{- if eq .Values.platform "k3s" }}
+          value: "{{ .Release.Name }}-console-svc:444"
+        {{- else }}
           value: "{{ .Release.Name }}-console-svc:443"
+        {{- end }}
         - name: SCALOCK_GATEWAY_PUBLIC_IP
           value: {{ .Values.gate.publicIP | default "aqua-gateway-svc" }}
         - name: HEALTH_MONITOR

--- a/server/templates/web-deployment.yaml
+++ b/server/templates/web-deployment.yaml
@@ -181,6 +181,9 @@ spec:
         - containerPort: 8080
           protocol: TCP
         - containerPort: 8443
+        {{- if eq .Values.platform "k3s" }}
+          hostPort: 8444
+        {{- end }}
           protocol: TCP
 {{- with .Values.web.livenessProbe }}
         livenessProbe:

--- a/server/templates/web-service.yaml
+++ b/server/templates/web-service.yaml
@@ -20,6 +20,19 @@ spec:
   selector:
     app: {{ .Release.Name }}-console
   ports:
+  {{- if eq .Values.platform "k3s"}}
+  {{- range $port := .Values.web.service.k3sPorts }}
+    - name: {{ $port.name }}
+      port: {{ $port.port }}
+      targetPort: {{ $port.targetPort }}
+      {{- if $port.nodePort }}
+      nodePort: {{ $port.nodePort }}
+      {{- end }}
+      {{- if $port.protocol }}
+      protocol: {{ $port.protocol }}
+      {{- end }}
+  {{- end }}
+  {{- else }}
   {{- range $port := .Values.web.service.ports }}
     - name: {{ $port.name }}
       port: {{ $port.port }}
@@ -30,4 +43,5 @@ spec:
       {{- if $port.protocol }}
       protocol: {{ $port.protocol }}
       {{- end }}
+  {{- end }}
   {{- end }}

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -20,6 +20,7 @@ rbac:
 # tkgi = VMware Tanzu kubernetes Grid Integrated Edition
 # k8s = Plain/on-prem Vanilla Kubernetes
 # rancher = Rancher Kubernetes Platform
+# gs = GaintSwarm platform
 # k3s = k3s kubernetes platform
 platform: ""
 
@@ -217,6 +218,9 @@ web:
     type: LoadBalancer
     loadbalancerIP: "" # Specify loadBalancerIP address for aqua-gateway in AKS platform
     annotations: {}
+      # service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+      # service.beta.kubernetes.io/aws-load-balancer-internal: "false"
+      # service.beta.kubernetes.io/aws-load-balancer-type: nlb
     ports:
       - name: aqua-web
         port: 8080
@@ -329,11 +333,11 @@ envoy:
       protocol: TCP
     #As 443, 8443 already occupied in k3s kubernetes by traefik ingress. below are the envoy service ports
     k3sPorts:
-      - name: https
-        port: 445
-        targetPort: 8443
-        nodePort:
-        protocol: TCP
+    - name: https
+      port: 445
+      targetPort: 8443
+      nodePort:
+      protocol: TCP
 
   # Enabling Envoy requires the use of TLS certificates for the listener section, while the cluster TLS section is optional and to be enabled if TLS is in use for gate and web.
   # Find the instructions in the readme for help with generating the required certificates.

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -20,6 +20,7 @@ rbac:
 # tkgi = VMware Tanzu kubernetes Grid Integrated Edition
 # k8s = Plain/on-prem Vanilla Kubernetes
 # rancher = Rancher Kubernetes Platform
+# k3s = k3s kubernetes platform
 platform: ""
 
 openshift_route:
@@ -227,6 +228,18 @@ web:
         targetPort: 8443
         nodePort:
         protocol: TCP
+    #As 443, 8443 already occupied in k3s kubernetes by traefik ingress. below are the console ports
+    k3sPorts:
+      - name: aqua-web
+        port: 8080
+        targetPort: 8080
+        nodePort:
+        protocol: TCP
+      - name: aqua-web-ssl
+        port: 444
+        targetPort: 8443
+        nodePort:
+        protocol: TCP
   ingress:
     enabled: false
     externalPort:
@@ -314,6 +327,13 @@ envoy:
       targetPort: 8443
       nodePort:
       protocol: TCP
+    #As 443, 8443 already occupied in k3s kubernetes by traefik ingress. below are the envoy service ports
+    k3sPorts:
+      - name: https
+        port: 445
+        targetPort: 8443
+        nodePort:
+        protocol: TCP
 
   # Enabling Envoy requires the use of TLS certificates for the listener section, while the cluster TLS section is optional and to be enabled if TLS is in use for gate and web.
   # Find the instructions in the readme for help with generating the required certificates.


### PR DESCRIPTION
adding k3s platform support to server chart.
1. using --set "platform=k3s" can deploy server chart in k3s orchestrator.
2. using --set "platform=gs" can deploy server chart in gaintswarm orchestrator.
3. fixed serviceaccount bug in scanner chart