### PR TITLE
FIX: kube-enforcer namespace is taken from values and not static

### DIFF
--- a/kube-enforcer-starboard/templates/kube-enforcer-starboard-deploy.yaml
+++ b/kube-enforcer-starboard/templates/kube-enforcer-starboard-deploy.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.starboard.appName }}
-  namespace: aqua
+  namespace: {{ .Values.namespace }}
   labels:
     app: {{ .Values.starboard.appName }}
 spec:


### PR DESCRIPTION
In kube-enforcer-starboard-deploy.yaml the namespace values is set static to "aqua" and doesn't take the value from the values.yaml file