### PR TITLE
Allow web ingress path to be configured

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -367,6 +367,7 @@ Parameter | Description | Default| Mandatory
 `web.ingress.enabled` |	If true, Ingress will be created | `false`| `NO`
 `web.ingress.annotations` |	Ingress annotations	| `[]`| `NO`
 `web.ingress.hosts` | Ingress hostnames |	`[]`| `NO`
+`web.ingress.path` |	Ingress Path | `/`| `NO`
 `web.ingress.tls` |	Ingress TLS configuration (YAML) | `[]`| `NO`
 `web.securityContext` | Set of security context for the container | `nil`| `NO`
 `web.TLS.enabled` | If require secure channel communication | `false` | `NO`

--- a/server/templates/web-ingress.yaml
+++ b/server/templates/web-ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.web.ingress.enabled -}}
 {{- $fullname := .Release.Name -}}
 {{- $servicePort := (index .Values.web.service.ports 0).port -}}
+{{- $ingressPath := .Values.web.ingress.path -}}
 ---
 {{- if (semverCompare ">= 1.14" .Capabilities.KubeVersion.GitVersion) }}
 apiVersion: networking.k8s.io/v1beta1
@@ -26,7 +27,7 @@ spec:
       - host: {{ $host }}
         http:
           paths:
-            - path: /
+            - path: {{ $ingressPath }}
               backend:
                 serviceName: {{ $fullname }}-console-svc
                 servicePort: {{ $servicePort }}

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -243,7 +243,8 @@ web:
     annotations: {}
     #  kubernetes.io/ingress.class: nginx
     hosts: #REQUIRED
-    #- aquasec-test.example.com
+    - aquasec-test.example.com
+    path: /
     tls: []
     #  - secretName: aquasec-tls
     #    hosts:

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -243,7 +243,7 @@ web:
     annotations: {}
     #  kubernetes.io/ingress.class: nginx
     hosts: #REQUIRED
-    - aquasec-test.example.com
+    # - aquasec-test.example.com
     path: /
     tls: []
     #  - secretName: aquasec-tls


### PR DESCRIPTION
This patch allows the Ingress Path to be configured.

This is required when using the AWS ALB ingress controller for Ingress as you need the path to be `/*` rather than `/` with this ingress controller