### PR TITLE
Allow creation of the kube-enforcer-token secret to be disabled

### DIFF
--- a/kube-enforcer/README.md
+++ b/kube-enforcer/README.md
@@ -13,6 +13,8 @@ This page provides instructions for using HELM charts for configuring and deploy
     - [Clone the GitHub repository with the charts](#clone-the-github-repository-with-the-charts)
     - [Configure TLS authentication between the KubeEnforcer and the API Server](#configure-tls-authentication-between-the-kubeenforcer-and-the-api-server)
   - [Deploying the HELM chart](#deploying-the-helm-chart)
+    - [Installing Aqua Kube-Enforcer from Github Repo](#installing-aqua-kube-enforcer-from-github-repo)
+    - [Installing Aqua Kube-Enforcer from Helm Private Repository](#installing-aqua-kube-enforcer-from-helm-private-repository)
   - [Configuration for discovery](#configuration-for-discovery)
   - [Configuration for performing kube-bench scans](#configuration-for-performing-kube-bench-scans)
   - [Configurable parameters](#configurable-parameters)
@@ -161,6 +163,7 @@ To perform kube-bench scans in the cluster, the KubeEnforcer needs:
 | `imageCredentials.name`           | Your Docker pull image secret name                                          | `aqua-registry-secret`    | `YES - New cluster`     |
 | `imageCredentials.username`       | Your Docker registry (DockerHub, etc.) username                             | `N/A`                     | `YES - New cluster`     |
 | `imageCredentials.password`       | Your Docker registry (DockerHub, etc.) password                             | `N/A`                     | `YES - New cluster`     |
+| `aquaSecret.create`               | Set to create the Aqua KubeEnforcer token secret                            | `true`                    | `YES`                   |
 | `aquaSecret.kubeEnforcerToken`    | Aqua KubeEnforcer token                                                     | `N/A`                     | `YES`                   |
 | `certsSecret.create`              | Set to create new secret for KE certs                                       | `true`                    | `YES`                   |
 | `certsSecret.name`                | Secret name for KE certs                                                    | `aqua-kube-enforcer-certs`| `YES`                   |

--- a/kube-enforcer/templates/kube-enforcer-token.yaml
+++ b/kube-enforcer/templates/kube-enforcer-token.yaml
@@ -1,3 +1,4 @@
+{{ if  .Values.aquaSecret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,3 +7,4 @@ metadata:
 type: Opaque
 data:
   token: {{ .Values.aquaSecret.kubeEnforcerToken | b64enc }}               # aqua kube enforcer token
+{{ end }}

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -35,6 +35,7 @@ certsSecret:
   serverKey: ""
 
 aquaSecret:
+  create: true
   name: aqua-kube-enforcer-token
 # Enter the enforcer token in "clear-text" format without quotes generated from the Console UI
   kubeEnforcerToken:


### PR DESCRIPTION
This change allow the creation of the kube-enforcer-token secret to be disabled in the case where you want to provision the secret outside the kube-enforcer helm chart