### PR TITLE
6.2 | Sever | Enhancement | adding aquasec registry envoy image

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -388,7 +388,8 @@ Parameter | Description | Default| Mandatory
 `envoy.service.type` | k8s service type | `LoadBalancer`| `NO`
 `envoy.service.loadbalancerIP` | can specify loadBalancerIP address for aqua-web in AKS platform | `null` | `NO`
 `envoy.service.ports` | array of ports settings | `array`| `NO`
-`envoy.TLS.listener.secretName` | certificates secret name | `nil` | `YES` <br /> `if envoy.enabled is set to true`
+`envoy.TLS.listener.enabled` | enable to load custom self-signed or CA certs | `false` | `NO` <br /> `if envoy.enabled is set to true`
+`envoy.TLS.listener.secretName` | certificates secret name | `nil` | `NO` <br /> `if envoy.enabled is set to true`
 `envoy.TLS.listener.publicKey_fileName` | filename of the public key eg: aqua-lb.fqdn.crt | `nil`  |  `YES` <br /> `if envoy.enabled is set to true`
 `envoy.TLS.listener.privateKey_fileName`   | filename of the private key eg: aqua-lb.fqdn.key | `nil`  |  `YES` <br /> `if envoy.enabled is set to true`
 `envoy.TLS.listener.rootCA_fileName` |  filename of the rootCA, if using self-signed certificates eg: rootCA.crt | `nil`  |  `NO`

--- a/server/conf/envoy.yaml.tpl
+++ b/server/conf/envoy.yaml.tpl
@@ -47,7 +47,7 @@ static_resources:
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
           common_tls_context:
-            {{- if .Values.envoy.TLS.listener.rootCA_fileName }}
+            {{- if and (.Values.envoy.TLS.listener.rootCA_fileName) (.Values.envoy.TLS.listener.enabled) }}
             validation_context:
               trusted_ca:
                 filename: "/etc/ssl/envoy/listener/{{ .Values.envoy.TLS.listener.rootCA_fileName }}"
@@ -55,9 +55,17 @@ static_resources:
             alpn_protocols: "h2,http/1.1"
             tls_certificates:
             - certificate_chain:
+                {{- if .Values.envoy.TLS.listener.enabled }}
                 filename: "/etc/ssl/envoy/listener/{{ .Values.envoy.TLS.listener.publicKey_fileName }}"
+                {{- else }}
+                filename: "/etc/ssl/envoy/tls.crt"
+                {{- end }}
               private_key:
+                {{- if .Values.envoy.TLS.listener.enabled }}
                 filename: "/etc/ssl/envoy/listener/{{ .Values.envoy.TLS.listener.privateKey_fileName }}"
+                {{- else }}
+                filename: "/etc/ssl/envoy/tls.key"
+                {{- end }}
   clusters:
   - name: aqua-gateway-svc
     connect_timeout: 180s

--- a/server/templates/envoy-deployment.yaml
+++ b/server/templates/envoy-deployment.yaml
@@ -31,8 +31,9 @@ spec:
     spec:
       securityContext:
         {{ toYaml .Values.envoy.securityContext | nindent 8 }}
+      serviceAccount: {{ .Release.Namespace }}-sa
       containers:
-      - image: "{{ .Values.envoy.image.repository }}:{{ .Values.envoy.image.tag }}"
+      - image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.envoy.image.repository }}:{{ .Values.envoy.image.tag }}"
         imagePullPolicy: "{{ .Values.envoy.image.pullPolicy }}"
         name: envoy
         env:
@@ -48,8 +49,10 @@ spec:
         volumeMounts:
         - mountPath: /etc/envoy
           name: config
+        {{- if .Values.envoy.TLS.listener.enabled }}
         - mountPath: /etc/ssl/envoy/listener
           name: listener-certs
+        {{- end }}
         {{ if .Values.envoy.TLS.cluster.enabled }}
         - mountPath: /etc/ssl/envoy/cluster
           name: cluster-certs
@@ -83,10 +86,12 @@ spec:
           defaultMode: 420
           name: {{ .Release.Name }}-envoy-conf
         name: config
+      {{- if .Values.envoy.TLS.listener.enabled }}
       - name: listener-certs
         secret:
           defaultMode: 420
           secretName: {{ .Values.envoy.TLS.listener.secretName }}
+      {{- end }}
       {{ if .Values.envoy.TLS.cluster.enabled }}
       - name: cluster-certs
         secret:

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -321,8 +321,8 @@ envoy:
   replicaCount: 1
 
   image:
-    repository: envoyproxy/envoy-alpine
-    tag: v1.15.0
+    repository: envoy
+    tag: "6.2"
     pullPolicy: IfNotPresent
   
   service:
@@ -350,6 +350,7 @@ envoy:
   # Find the instructions in the readme for help with generating the required certificates.
   TLS:
     listener:
+      enabled: false                    # true to enable loading custom self-signed or CA certs, by default envoy uses packaged self-signed certs
       secretName: "aqua-lb-tls"         # provide secret name containing the certificates
       publicKey_fileName: ""            # provide filename of the public key in the secret eg: aqua-lb.fqdn.crt
       privateKey_fileName: ""           # provide filename of the private key in the secret eg: aqua-lb.fqdn.key


### PR DESCRIPTION
changing the envoy image to: registry.aquasec.com/envoy:5.3
making certs for envoy optional, as aquasec envoy image have self-signed certs.
adding serviceAccount: aqua-sa 