### PR TITLE
Fix ServiceAccount name on ClusterRoleBinding

### DIFF
--- a/server/templates/rbac.yaml
+++ b/server/templates/rbac.yaml
@@ -60,7 +60,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-sa
+    name: {{ .Release.Namespace }}-sa
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
@@ -81,7 +81,7 @@ metadata:
   name: cluster-reader
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-sa
+    name: {{ .Release.Namespace }}-sa
     namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This change fixes KubeDiscovery to work for the Gateways