### PR TITLE
6.2 | Fix | Kube-enforcer, Kube-Enforcer-Starboard and Enforcer multiple fixes

### DIFF
--- a/enforcer/templates/_helpers.tpl
+++ b/enforcer/templates/_helpers.tpl
@@ -45,3 +45,7 @@ Inject extra environment populated by secrets, if populated
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "platform" }}
+{{- printf "%s" (required "A valid .Values.platform entry required" .Values.platform ) | replace "\n" "" }}
+{{- end }}

--- a/enforcer/templates/rbac.yaml
+++ b/enforcer/templates/rbac.yaml
@@ -1,0 +1,152 @@
+{{- if .Values.rbac.create -}}
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+    name: {{ .Release.Name }}-psp
+    labels:
+      app: {{ .Release.Name }}
+      chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+      release: "{{ .Release.Name }}"
+      heritage: "{{ .Release.Service }}"
+spec:
+  privileged: {{ .Values.rbac.privileged }}
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-cluster-role
+  labels:
+    app: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    rbac.example.com/aggregate-to-monitoring: "true"
+rules:
+- apiGroups: ["extensions"]
+  resourceNames: [{{ .Release.Name }}-psp]
+  resources: ["podsecuritypolicies"]
+  verbs: ["use"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-role-binding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Namespace }}-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  {{- if .Values.rbac.roleRef }}
+  name: {{ .Values.rbac.roleRef }}
+  {{- else }}
+  name: {{ .Release.Name }}-cluster-role
+  {{- end }}
+
+{{- if not .Values.platform -}}
+{{ template "platform" .}}
+{{- else if eq .Values.platform "openshift" }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cluster-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Namespace }}-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-reader
+---
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: true
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+- SYS_ADMIN
+- NET_ADMIN
+- NET_RAW
+- SYS_PTRACE
+- KILL
+- MKNOD
+- SETGID
+- SETUID
+- SYS_MODULE
+- AUDIT_CONTROL
+- SYSLOG
+- SYS_CHROOT
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: aqua scc provides all features of the restricted SCC
+      but allows users to run with any non-root UID and access hostPath. The user must
+      specify the UID or it must be specified on the by the manifest of the container runtime.
+    release.openshift.io/create-only: "true"
+  name: aqua-scc
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:aqua:aqua-sa
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret
+- hostPath
+
+{{- else if eq .Values.platform "tkg" }}
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rolebinding-default-privileged-sa-ns_default
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: psp:vmware-system-privileged
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: system:serviceaccounts
+{{- end -}}
+{{- end }}

--- a/enforcer/values.yaml
+++ b/enforcer/values.yaml
@@ -7,7 +7,22 @@ imageCredentials:
   password: ""
 
 serviceAccount:
-  create: false # change to true if deploying enforcer on new cluster or aqua-sa serviceaccount not exists.
+  create: false # change to true if deploying enforcer on new cluster or aqua-sa serviceaccount doesn't exist.
+
+rbac:
+  create: false # change to true if deploying enforcer on new cluster or rbac for aqua-sa doesn't exist.
+
+#Please specify k8s platform acronym. Allowed values are aks, eks, gke, openshift, tkg, tkgi, k8s
+# aks = Azure Kubernetes Service
+# gke = Google kubernetes Engine
+# openshift = RedHat Openshift/OCP
+# tkg = VMware Tanzu kubernetes Grid
+# tkgi = VMware Tanzu kubernetes Grid Integrated Edition
+# k8s = Plain/on-prem Vanilla Kubernetes
+# rancher = Rancher Kubernetes Platform
+# gs = GaintSwarm platform
+# k3s = k3s kubernetes platform
+platform: ""
 
 # Enter the enforcer token in "clear-text" format without quotes generated from the Console UI
 enforcerToken: 

--- a/kube-enforcer-starboard/templates/kube-enforcer-deployment.yaml
+++ b/kube-enforcer-starboard/templates/kube-enforcer-deployment.yaml
@@ -118,6 +118,10 @@ spec:
           readinessProbe:
 {{ toYaml . | indent 12 }}
 {{- end }}
+{{- with .Values.kubeEnforcerAdvance.envoy.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+{{- end }}
 {{- end }}
       volumes:
         - name: "certs"

--- a/kube-enforcer-starboard/templates/mutating-webhook.yaml
+++ b/kube-enforcer-starboard/templates/mutating-webhook.yaml
@@ -12,7 +12,9 @@ webhooks:
         apiVersions: ["*"]
         resources: ["pods"]
     clientConfig:
+      {{- if not .Values.webhooks.certManager }}
       caBundle: {{ template "caBundle" . }}
+      {{- end }}
       service:
         namespace: {{ .Values.namespace }}
         name: {{ include "kube-enforcer.fullname" . }}

--- a/kube-enforcer-starboard/templates/mutating-webhook.yaml
+++ b/kube-enforcer-starboard/templates/mutating-webhook.yaml
@@ -1,10 +1,12 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ .Values.webhooks.mutatingWebhook.name }}
   namespace: {{ .Values.namespace }}
 webhooks:
   - name: microenforcer.aquasec.com
+    sideEffects: "None"
+    admissionReviewVersions: ["v1", "v1beta1"]
     failurePolicy: {{ .Values.webhooks.failurePolicy }}
     rules:
       - operations: ["CREATE", "UPDATE"]

--- a/kube-enforcer-starboard/templates/validating-webhook.yaml
+++ b/kube-enforcer-starboard/templates/validating-webhook.yaml
@@ -1,11 +1,13 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ .Values.webhooks.validatingWebhook.name }}
   namespace: {{ .Values.namespace }}
 webhooks:
   - name: imageassurance.aquasec.com
-    failurePolicy: {{ .Values.webhooks.failurePolicy }}  
+    failurePolicy: {{ .Values.webhooks.failurePolicy }}
+    sideEffects: "None"
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - operations: ["CREATE"]
         apiGroups: ["*"]

--- a/kube-enforcer-starboard/templates/validating-webhook.yaml
+++ b/kube-enforcer-starboard/templates/validating-webhook.yaml
@@ -12,7 +12,9 @@ webhooks:
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]
     clientConfig:
+      {{- if not .Values.webhooks.certManager }}
       caBundle: {{ template "caBundle" . }}
+      {{- end }}
       service:
         namespace: {{ .Values.namespace }}
         name: {{ include "kube-enforcer.fullname" . }}

--- a/kube-enforcer-starboard/values.yaml
+++ b/kube-enforcer-starboard/values.yaml
@@ -57,7 +57,8 @@ roleBinding:
   name: aqua-kube-enforcer 
 
 webhooks:
-  caBundle: ""
+  caBundle: "" # this field is required unless you're using Kubernetes cert-manager (set the flag below to true)
+  certManager: false # set this field true if you're using cert-manager and don't need to pass a caBundle
   failurePolicy: Ignore
   validatingWebhook:
     name: kube-enforcer-admission-hook-config

--- a/kube-enforcer/templates/kube-enforcer-deployment.yaml
+++ b/kube-enforcer/templates/kube-enforcer-deployment.yaml
@@ -59,8 +59,6 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.aquaSecret.name }}
                   key: token
-            # Specify whether to enable/disable the cache by using "yes", "true", "no", "false" values.
-            # Default value is "yes".
             - name: AQUA_ENABLE_CACHE
               value: "{{ .Values.aqua_enable_cache }}"
             - name: AQUA_CACHE_EXPIRATION_PERIOD

--- a/kube-enforcer/templates/kube-enforcer-deployment.yaml
+++ b/kube-enforcer/templates/kube-enforcer-deployment.yaml
@@ -63,6 +63,8 @@ spec:
               value: "{{ .Values.aqua_enable_cache }}"
             - name: AQUA_CACHE_EXPIRATION_PERIOD
               value: "{{ .Values.aqua_cache_expiration_period }}"
+            - name: AQUA_LOGICAL_NAME
+              value: "{{ .Values.logicalName }}"
             - name: TLS_SERVER_CERT_FILEPATH
               value: /certs/server.crt
             - name: TLS_SERVER_KEY_FILEPATH

--- a/kube-enforcer/templates/kube-enforcer-deployment.yaml
+++ b/kube-enforcer/templates/kube-enforcer-deployment.yaml
@@ -135,6 +135,10 @@ spec:
           readinessProbe:
 {{ toYaml . | indent 12 }}
 {{- end }}
+{{- with .Values.kubeEnforcerAdvance.envoy.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+{{- end }}
 {{- end }}
       volumes:
         - name: "certs"

--- a/kube-enforcer/templates/mutating-webhook.yaml
+++ b/kube-enforcer/templates/mutating-webhook.yaml
@@ -12,7 +12,9 @@ webhooks:
         apiVersions: ["*"]
         resources: ["pods"]
     clientConfig:
+      {{- if not .Values.webhooks.certManager }}
       caBundle: {{ template "caBundle" . }}
+      {{- end }}
       service:
         namespace: {{ .Values.namespace }}
         name: {{ include "kube-enforcer.fullname" . }}

--- a/kube-enforcer/templates/mutating-webhook.yaml
+++ b/kube-enforcer/templates/mutating-webhook.yaml
@@ -1,10 +1,12 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ .Values.webhooks.mutatingWebhook.name }}
   namespace: {{ .Values.namespace }}
 webhooks:
   - name: microenforcer.aquasec.com
+    sideEffects: "None"
+    admissionReviewVersions: ["v1", "v1beta1"]
     failurePolicy: {{ .Values.webhooks.failurePolicy }}
     rules:
       - operations: ["CREATE", "UPDATE"]

--- a/kube-enforcer/templates/validating-webhook.yaml
+++ b/kube-enforcer/templates/validating-webhook.yaml
@@ -1,11 +1,13 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ .Values.webhooks.validatingWebhook.name }}
   namespace: {{ .Values.namespace }}
 webhooks:
   - name: imageassurance.aquasec.com
-    failurePolicy: {{ .Values.webhooks.failurePolicy }}  
+    failurePolicy: {{ .Values.webhooks.failurePolicy }}
+    sideEffects: "None"
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - operations: ["CREATE"]
         apiGroups: ["*"]

--- a/kube-enforcer/templates/validating-webhook.yaml
+++ b/kube-enforcer/templates/validating-webhook.yaml
@@ -12,7 +12,9 @@ webhooks:
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]
     clientConfig:
+      {{- if not .Values.webhooks.certManager }}
       caBundle: {{ template "caBundle" . }}
+      {{- end }}
       service:
         namespace: {{ .Values.namespace }}
         name: {{ include "kube-enforcer.fullname" . }}

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -12,7 +12,7 @@ imageCredentials:
 managed: false
 environment: aws # aws, acs, onprem
 
-aqua_enable_cache: yes
+aqua_enable_cache: yes # Specify whether to enable/disable the cache by using "yes", "true", "no", "false" values.
 aqua_cache_expiration_period: 60
 
 image:

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -60,7 +60,8 @@ roleBinding:
   name: aqua-kube-enforcer 
 
 webhooks:
-  caBundle: ""
+  caBundle: "" # this field is required unless you're using Kubernetes cert-manager (set the flag below to true)
+  certManager: false # set this field true if you're using cert-manager and don't need to pass a caBundle
   failurePolicy: Ignore
   validatingWebhook:
     name: kube-enforcer-admission-hook-config

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -24,6 +24,7 @@ nameOverride: "aqua-kube-enforcer"
 fullnameOverride: "aqua-kube-enforcer"
 
 namespace: "aqua"
+logicalName: ""
 
 logLevel: ""
 


### PR DESCRIPTION
You can find each one of the following fixes in their own commits

Fixes:
- [KE, KE-Starboard]: Envoy resources block ignored by deployment template
- [KE, KE-Starboard]: Replacing deprecated admissionregistration.k8s.io/v1beta1 -> admissionregistration.k8s.io/v1
- [KE]: AQUA_LOGICAL_NAME missing in values
- [E]: Missing PSP if enforcer is deployed in a different cluster than Server

Improvements:
- [KE, KE-Starboard]: Not forcing to pass caBundle if clients are using cert-manager