### PR TITLE
6.2 | Improvements | Scanner, KE, KES

### DIFF
--- a/kube-enforcer-starboard/conf/envoy.yaml.tpl
+++ b/kube-enforcer-starboard/conf/envoy.yaml.tpl
@@ -1,5 +1,5 @@
 node:
-  cluster: {{ .Values.kubeEnforcerAdvance.clusterName | default "k8s" }}
+  cluster: {{ .Values.clusterName | default "k8s" }}
   id: {{ .Values.kubeEnforcerAdvance.nodeID | default "envoy" }}
 
 dynamic_resources:

--- a/kube-enforcer-starboard/templates/kube-enforcer-deployment.yaml
+++ b/kube-enforcer-starboard/templates/kube-enforcer-deployment.yaml
@@ -62,7 +62,7 @@ spec:
             - name: AQUA_LOGICAL_NAME
               value: "{{ .Values.logicalName }}"
             - name: CLUSTER_NAME
-              value: {{ .Values.clusterName | default "aqua-secure" }}  
+              value: {{ .Values.clusterName }}
             - name: TLS_SERVER_CERT_FILEPATH
               value: /certs/server.crt
             - name: TLS_SERVER_KEY_FILEPATH

--- a/kube-enforcer-starboard/values.yaml
+++ b/kube-enforcer-starboard/values.yaml
@@ -19,8 +19,8 @@ image:
 nameOverride: "aqua-kube-enforcer"
 fullnameOverride: "aqua-kube-enforcer"
 
+clusterName: ""   # Display a custom cluster name in the infrastructure tab of Aqua Enterprise
 logicalName: ""
-
 logLevel: ""
 
 # Set create to false if you want to use an existing secret for the kube-enforcer certs
@@ -165,7 +165,6 @@ starboard:
 
 kubeEnforcerAdvance:
   enable: false
-  clusterName: "k8s"
   nodeID: "envoy"
 
   envoy:

--- a/kube-enforcer/conf/envoy.yaml.tpl
+++ b/kube-enforcer/conf/envoy.yaml.tpl
@@ -1,5 +1,5 @@
 node:
-  cluster: {{ .Values.kubeEnforcerAdvance.clusterName | default "k8s" }}
+  cluster: {{ .Values.clusterName | default "k8s" }}
   id: {{ .Values.kubeEnforcerAdvance.nodeID | default "envoy" }}
 
 dynamic_resources:

--- a/kube-enforcer/templates/kube-enforcer-deployment.yaml
+++ b/kube-enforcer/templates/kube-enforcer-deployment.yaml
@@ -65,6 +65,8 @@ spec:
               value: "{{ .Values.aqua_cache_expiration_period }}"
             - name: AQUA_LOGICAL_NAME
               value: "{{ .Values.logicalName }}"
+            - name: CLUSTER_NAME
+              value: {{ .Values.clusterName }}
             - name: TLS_SERVER_CERT_FILEPATH
               value: /certs/server.crt
             - name: TLS_SERVER_KEY_FILEPATH
@@ -97,8 +99,6 @@ spec:
             {{- include "kube-enforcer.extraEnvironmentVars" .Values | nindent 12 }}
             {{- include "kube-enforcer.extraSecretEnvironmentVars" .Values | nindent 12 }}
 {{- if .Values.kubeEnforcerAdvance.enable }}
-            - name: CLUSTER_NAME
-              value: {{ .Values.kubeEnforcerAdvance.clusterName | default "aqua-secure" }}   # Cluster display name in aqua enterprise.
             - name: AQUA_ENVOY_MODE
               value: "true"
 {{- end }}

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -19,8 +19,8 @@ image:
 nameOverride: "aqua-kube-enforcer"
 fullnameOverride: "aqua-kube-enforcer"
 
+clusterName: ""   # Display a custom cluster name in the infrastructure tab of Aqua Enterprise
 logicalName: ""
-
 logLevel: ""
 
 # Set create to false if you want to use an existing secret for the kube-enforcer certs
@@ -125,7 +125,6 @@ extraSecretEnvironmentVars: []
 
 kubeEnforcerAdvance:
   enable: false
-  clusterName: "k8s"
   nodeID: "envoy"
 
   envoy:

--- a/scanner/templates/scanner-deployment.yaml
+++ b/scanner/templates/scanner-deployment.yaml
@@ -48,7 +48,9 @@ spec:
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         args:
         - daemon
+        {{- if .Values.directCC.enabled }}
         - --direct-cc
+        {{- end }}
         - --user
         {{- if .Values.scannerUserSecret.enable }}
         - "$(SCANNER_USER)"

--- a/scanner/values.yaml
+++ b/scanner/values.yaml
@@ -11,6 +11,9 @@ dockerSock:
   mount: # put true for mount docker socket.
   path: /var/run/docker.sock # pks - /var/vcap/data/sys/run/docker/docker.sock
 
+directCC:
+  enabled: true     # Change it to false if the scanners don't connect directly to CyberCenter but only console does
+
 serviceAccount:
   create: false     #Change it to false if the cluster doesn't consists aqua service account
   name: "aqua-sa"   #Mention the Service Account name, Default "aqua-sa"

--- a/server/templates/db-deployment.yaml
+++ b/server/templates/db-deployment.yaml
@@ -144,6 +144,11 @@ spec:
       {{- if and (.Values.db.tolerations) (semverCompare "<1.6-0" .Capabilities.KubeVersion.GitVersion) }}
         scheduler.alpha.kubernetes.io/tolerations: '{{ toJson .Values.db.tolerations }}'
       {{- end }}
+      {{- with .Values.db.podAnnotations }}
+      {{- range $key,$value := . }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
       labels:
         app: {{ .Release.Name }}-audit-database
       name: {{ .Release.Name }}-audit-database


### PR DESCRIPTION
Scanner:
- making direct-cc option available in the values

KE, KES:
- CLUSTER_NAME: making option available in the values outside advanced envoy configuration (users may want to use it without necessarily enabling envoy)
- CLUSTER_NAME: default value can stay empty, it'll use cluster ID
- CLUSTER_NAME: default value for envoy stays set to k8s if not cluster name is passed
