### PR TITLE
6.5 | fixing KE issues and adding namespace to all component templates

### DIFF
--- a/enforcer/templates/_helpers.tpl
+++ b/enforcer/templates/_helpers.tpl
@@ -45,3 +45,7 @@ Inject extra environment populated by secrets, if populated
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "platform" }}
+{{- printf "%s" (required "A valid .Values.platform entry required" .Values.platform ) | replace "\n" "" }}
+{{- end }}

--- a/enforcer/templates/enforcer-daemonset.yaml
+++ b/enforcer/templates/enforcer-daemonset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ .Release.Name }}-ds
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-ds
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/enforcer/templates/enforcer-token-secret.yaml
+++ b/enforcer/templates/enforcer-token-secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-token
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-token
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/enforcer/templates/image-pull-secret.yaml
+++ b/enforcer/templates/image-pull-secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Namespace }}-registry-secret
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/enforcer/templates/rbac.yaml
+++ b/enforcer/templates/rbac.yaml
@@ -1,0 +1,152 @@
+{{- if .Values.rbac.create -}}
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+    name: {{ .Release.Name }}-psp
+    labels:
+      app: {{ .Release.Name }}
+      chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+      release: "{{ .Release.Name }}"
+      heritage: "{{ .Release.Service }}"
+spec:
+  privileged: {{ .Values.rbac.privileged }}
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-cluster-role
+  labels:
+    app: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    rbac.example.com/aggregate-to-monitoring: "true"
+rules:
+- apiGroups: ["extensions"]
+  resourceNames: [{{ .Release.Name }}-psp]
+  resources: ["podsecuritypolicies"]
+  verbs: ["use"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-role-binding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Namespace }}-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  {{- if .Values.rbac.roleRef }}
+  name: {{ .Values.rbac.roleRef }}
+  {{- else }}
+  name: {{ .Release.Name }}-cluster-role
+  {{- end }}
+
+{{- if not .Values.platform -}}
+{{ template "platform" .}}
+{{- else if eq .Values.platform "openshift" }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cluster-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Namespace }}-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-reader
+---
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: true
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+- SYS_ADMIN
+- NET_ADMIN
+- NET_RAW
+- SYS_PTRACE
+- KILL
+- MKNOD
+- SETGID
+- SETUID
+- SYS_MODULE
+- AUDIT_CONTROL
+- SYSLOG
+- SYS_CHROOT
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: aqua scc provides all features of the restricted SCC
+      but allows users to run with any non-root UID and access hostPath. The user must
+      specify the UID or it must be specified on the by the manifest of the container runtime.
+    release.openshift.io/create-only: "true"
+  name: aqua-scc
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:aqua:aqua-sa
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret
+- hostPath
+
+{{- else if eq .Values.platform "tkg" }}
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rolebinding-default-privileged-sa-ns_default
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: psp:vmware-system-privileged
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: system:serviceaccounts
+{{- end -}}
+{{- end }}

--- a/enforcer/templates/serviceaccount.yaml
+++ b/enforcer/templates/serviceaccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Release.Namespace }}-sa
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/enforcer/values.yaml
+++ b/enforcer/values.yaml
@@ -7,7 +7,22 @@ imageCredentials:
   password: ""
 
 serviceAccount:
-  create: false # change to true if deploying enforcer on new cluster or aqua-sa serviceaccount not exists.
+  create: false # change to true if deploying enforcer on new cluster or aqua-sa serviceaccount doesn't exist.
+
+rbac:
+  create: false # change to true if deploying enforcer on new cluster or rbac for aqua-sa doesn't exist.
+
+#Please specify k8s platform acronym. Allowed values are aks, eks, gke, openshift, tkg, tkgi, k8s
+# aks = Azure Kubernetes Service
+# gke = Google kubernetes Engine
+# openshift = RedHat Openshift/OCP
+# tkg = VMware Tanzu kubernetes Grid
+# tkgi = VMware Tanzu kubernetes Grid Integrated Edition
+# k8s = Plain/on-prem Vanilla Kubernetes
+# rancher = Rancher Kubernetes Platform
+# gs = GaintSwarm platform
+# k3s = k3s kubernetes platform
+platform: ""
 
 # Enter the enforcer token in "clear-text" format without quotes generated from the Console UI
 enforcerToken: 

--- a/gateway/templates/db-password-secret.yaml
+++ b/gateway/templates/db-password-secret.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-database-password
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-database
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -29,6 +30,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-database-password
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-database
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/gateway/templates/gate-deployment.yaml
+++ b/gateway/templates/gate-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-gateway
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-gateway
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/gateway/templates/gate-service.yaml
+++ b/gateway/templates/gate-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-gateway-svc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-gateway
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/gateway/templates/image-pull-secret.yaml
+++ b/gateway/templates/image-pull-secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.imageCredentials.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/gateway/templates/serviceaccount.yaml
+++ b/gateway/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/kube-enforcer/README.md
+++ b/kube-enforcer/README.md
@@ -178,6 +178,7 @@ To perform kube-bench scans in the cluster, the KubeEnforcer needs:
 | `imageCredentials.username`       | Your Docker registry (Docker Hub, etc.) username            | `N/A`    | `YES - New cluster`     |
 | `imageCredentials.password`       | Your Docker registry (Docker Hub, etc.) password            | `N/A`    | `YES - New cluster`     |
 | `aquaSecret.kubeEnforcerToken`    | Aqua KubeEnforcer (KE) token  | `N/A`    | `YES`  |
+| `clusterName`                     | Cluster name registered with Aqua in Infrastructure tab | `N/A` | `NO` |
 | `certsSecret.create`              | Set to create a new secret for KE certs     | `true`   | `YES`  |
 | `certsSecret.name`                | Secret name for KE certs | `aqua-kube-enforcer-certs`| `YES`  |
 | `certsSecret.serverCertificate`   | Certificate for TLS authentication with the Kubernetes api-server           | `N/A`    | `YES`  |
@@ -205,8 +206,7 @@ To perform kube-bench scans in the cluster, the KubeEnforcer needs:
 | `starboard.readinessProbe`  |
 | `starboard.livenessProbe`  |
 | `kubeEnforcerAdvance.enable`      | Advanced KubeEnforcer deployment          | `false`  | `NO`   |
-| `kubeEnforcerAdvance.clusterName` | Cluster name of the Advanced KE deployment | `k8s`    | `NO`   |
-| `kubeEnforcerAdvance.clusterID`   | Cluster name of the Advanced KE deployment | `N/A`    | `NO`   |
+| `kubeEnforcerAdvance.nodeID`      | Envoy Node ID of the advance KE deployment    | `envoy` | `YES - if kubeEnforcerAdvance.enable` |
 
 ## Issues and feedback
 

--- a/kube-enforcer/conf/cds.yaml.tpl
+++ b/kube-enforcer/conf/cds.yaml.tpl
@@ -1,0 +1,79 @@
+resources:
+  - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: aqua-kube-enforcer
+    connect_timeout: 180s
+    type: STRICT_DNS
+    dns_lookup_family: V4_ONLY
+    lb_policy: ROUND_ROBIN
+    http2_protocol_options:
+      hpack_table_size: 4294967
+      max_concurrent_streams: 2147483647
+    circuit_breakers:
+      thresholds:
+        max_pending_requests: 2147483647
+        max_requests: 2147483647
+    load_assignment:
+      cluster_name: aqua-kube-enforcer
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: localhost
+                    port_value: 8442
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        sni: aqua-kube-enforcer
+  - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: aqua-kube-enforcer-k8s
+    connect_timeout: 180s
+    type: STRICT_DNS
+    dns_lookup_family: V4_ONLY
+    lb_policy: ROUND_ROBIN
+    circuit_breakers:
+      thresholds:
+        max_pending_requests: 2147483647
+        max_requests: 2147483647
+    load_assignment:
+      cluster_name: aqua-kube-enforcer-k8s
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: localhost
+                    port_value: 8449
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        sni: aqua-kube-enforcer-k8s
+  - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: aqua-gateway
+    connect_timeout: 180s
+    type: STRICT_DNS
+    dns_lookup_family: V4_ONLY
+    lb_policy: ROUND_ROBIN
+    http2_protocol_options:
+      hpack_table_size: 4294967
+      max_concurrent_streams: 2147483647
+    circuit_breakers:
+      thresholds:
+        max_pending_requests: 2147483647
+        max_requests: 2147483647
+    load_assignment:
+      cluster_name: aqua-gateway
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: {{ .Values.gateway.address }}
+                    port_value: {{ .Values.gateway.port }}
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        sni: aqua-gateway

--- a/kube-enforcer/conf/envoy.yaml.tpl
+++ b/kube-enforcer/conf/envoy.yaml.tpl
@@ -1,0 +1,10 @@
+node:
+  cluster: {{ .Values.clusterName | default "k8s" }}
+  id: {{ .Values.kubeEnforcerAdvance.nodeID | default "envoy" }}
+
+dynamic_resources:
+  cds_config:
+    path: /etc/aquasec/envoy/cds.yaml
+    initial_fetch_timeout: 0s
+  lds_config:
+    path: /etc/envoy/lds.yaml

--- a/kube-enforcer/conf/lds.yaml.tpl
+++ b/kube-enforcer/conf/lds.yaml.tpl
@@ -1,0 +1,69 @@
+resources:
+  - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+    name: listener_0
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 8443
+    filter_chains:
+      - filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              stream_idle_timeout: 0s
+              drain_timeout: 20s
+              access_log:
+                - name: envoy.access_loggers.file
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                    path: "/dev/stdout"
+              codec_type: AUTO
+              stat_prefix: ingress_https
+              route_config:
+                name: local_route
+                virtual_hosts:
+                  - name: https
+                    domains:
+                      - "*"
+                    routes:
+                      - match:
+                          prefix: "/agent_grpc_channel.GWChannelV2/PushNotificationHandler"
+                          grpc: { }
+                        route:
+                          cluster: aqua-kube-enforcer
+                          timeout: 0s
+                      - match:
+                          prefix: "/"
+                          grpc: { }
+                        route:
+                          cluster: aqua-gateway
+                          timeout: 0s
+                      - match:
+                          prefix: "/"
+                        route:
+                          cluster: aqua-kube-enforcer-k8s
+                          timeout: 0s
+
+              http_filters:
+                - name: envoy.filters.http.health_check
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.config.filter.http.health_check.v2.HealthCheck
+                    pass_through_mode: false
+                    headers:
+                      - name: ":path"
+                        exact_match: "/healthz"
+                      - name: "x-envoy-livenessprobe"
+                        exact_match: "healthz"
+                - name: envoy.filters.http.router
+                  typed_config: { }
+        transport_socket:
+          name: envoy.transport_sockets.tls
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+            common_tls_context:
+              alpn_protocols: "h2,http/1.1"
+              tls_certificates:
+                - certificate_chain:
+                    filename: "/etc/ssl/envoy/server.crt"
+                  private_key:
+                    filename: "/etc/ssl/envoy/server.key"

--- a/kube-enforcer/conf/validation_context_sds_secret.yaml.tpl
+++ b/kube-enforcer/conf/validation_context_sds_secret.yaml.tpl
@@ -1,0 +1,6 @@
+resources:
+  - "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"
+    name: "validation_context_sds"
+    validation_context:
+      trusted_ca:
+        filename: /etc/aquasec/envoy/ca-certificates.crt

--- a/kube-enforcer/templates/cluster-role-binding.yaml
+++ b/kube-enforcer/templates/cluster-role-binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Values.clusterRoleBinding.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -10,13 +10,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}
-    namespace: {{ .Values.namespace }}
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Values.starboard.clusterRoleBinding.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -24,4 +24,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.starboard.serviceAccount.name }}
-    namespace: {{ .Values.namespace }}
+    namespace: {{ .Release.Namespace }}

--- a/kube-enforcer/templates/cluster-role.yaml
+++ b/kube-enforcer/templates/cluster-role.yaml
@@ -20,7 +20,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Values.starboard.clusterRole.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
       - ""

--- a/kube-enforcer/templates/custom-resorce-defination.yaml
+++ b/kube-enforcer/templates/custom-resorce-defination.yaml
@@ -3,6 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: configauditreports.aquasecurity.github.io
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/managed-by: starboard
 spec:

--- a/kube-enforcer/templates/envoy-config.yaml
+++ b/kube-enforcer/templates/envoy-config.yaml
@@ -3,15 +3,27 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-envoy-conf
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-envoy
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-{{- range $key, $value := .Values.kubeEnforcerAdvance.envoy.files }}
+{{- if gt (len .Values.kubeEnforcerAdvance.envoy.custom_envoy_files ) 0 }}
+{{- range $key, $value := .Values.kubeEnforcerAdvance.envoy.custom_envoy_files }}
   {{ $key }}: |-
 {{ $valueWithDefault := default "" $value -}}
 {{ tpl $valueWithDefault $ | indent 4 }}
 {{- end -}}
-{{- end -}}
+{{- else }}
+  envoy.yaml: |-
+{{ tpl (.Files.Get "conf/envoy.yaml.tpl") . | indent 4}}
+  cds.yaml: |-
+{{ tpl (.Files.Get "conf/cds.yaml.tpl") . | indent 4}}
+  lds.yaml: |-
+{{ tpl (.Files.Get "conf/lds.yaml.tpl") . | indent 4}}
+  validation_context_sds_secret.yaml: |-
+{{ tpl (.Files.Get "conf/validation_context_sds_secret.yaml.tpl") . | indent 4}}
+{{- end }}
+{{- end }}

--- a/kube-enforcer/templates/image-pull-secret.yaml
+++ b/kube-enforcer/templates/image-pull-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.imageCredentials.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/kube-enforcer/templates/kube-enforcer-certs.yaml
+++ b/kube-enforcer/templates/kube-enforcer-certs.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.certsSecret.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 data:
   server.crt: {{ template "serverCertificate" . }}  # place server cert
   server.key: {{ template "serverKey" . }}  # place server key

--- a/kube-enforcer/templates/kube-enforcer-deployment.yaml
+++ b/kube-enforcer/templates/kube-enforcer-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     role: {{ .Release.Name }}
     app: {{ include "kube-enforcer.fullname" . }}
   name: {{ include "kube-enforcer.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   template:
@@ -62,13 +62,13 @@ spec:
             - name: AQUA_LOGICAL_NAME
               value: "{{ .Values.logicalName }}"
             - name: CLUSTER_NAME
-              value: {{ .Values.clusterName | default "aqua-secure" }}  
+              value: {{ .Values.clusterName }}
             - name: TLS_SERVER_CERT_FILEPATH
               value: /certs/server.crt
             - name: TLS_SERVER_KEY_FILEPATH
               value: /certs/server.key
             - name: AQUA_GATEWAY_SECURE_ADDRESS
-              value: {{ .Values.envs.gatewayAddress }}
+              value: {{ .Values.gateway.address }}:{{ .Values.gateway.port }}
             - name: AQUA_KAP_ADD_ALL_CONTROL
               value: "true"
             - name: AQUA_WATCH_CONFIG_AUDIT_REPORT
@@ -116,6 +116,10 @@ spec:
 {{- end }}
 {{- with .Values.kubeEnforcerAdvance.envoy.readinessProbe }}
           readinessProbe:
+{{ toYaml . | indent 12 }}
+{{- end }}
+{{- with .Values.kubeEnforcerAdvance.envoy.resources }}
+          resources:
 {{ toYaml . | indent 12 }}
 {{- end }}
 {{- end }}

--- a/kube-enforcer/templates/kube-enforcer-starboard-deploy.yaml
+++ b/kube-enforcer/templates/kube-enforcer-starboard-deploy.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.starboard.appName }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Values.starboard.appName }}
 spec:
@@ -37,7 +37,7 @@ spec:
             {{- if .Values.starboard.OPERATOR_NAMESPACE }}
               value: {{ .Values.starboard.OPERATOR_NAMESPACE }}
             {{- else }}
-              value: {{ .Values.namespace }}
+              value: {{ .Release.Namespace }}
             {{- end }}
             - name: OPERATOR_TARGET_NAMESPACES
               value: "{{ .Values.starboard.OPERATOR_TARGET_NAMESPACES }}"

--- a/kube-enforcer/templates/kube-enforcer-token.yaml
+++ b/kube-enforcer/templates/kube-enforcer-token.yaml
@@ -1,8 +1,10 @@
+{{ if  .Values.aquaSecret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.aquaSecret.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
   token: {{ .Values.aquaSecret.kubeEnforcerToken | b64enc }}             # aqua kube enforcer token
+{{ end }}

--- a/kube-enforcer/templates/mutating-webhook.yaml
+++ b/kube-enforcer/templates/mutating-webhook.yaml
@@ -1,10 +1,12 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ .Values.webhooks.mutatingWebhook.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 webhooks:
   - name: microenforcer.aquasec.com
+    sideEffects: "None"
+    admissionReviewVersions: ["v1", "v1beta1"]
     failurePolicy: {{ .Values.webhooks.failurePolicy }}
     rules:
       - operations: ["CREATE", "UPDATE"]
@@ -12,9 +14,11 @@ webhooks:
         apiVersions: ["*"]
         resources: ["pods"]
     clientConfig:
+      {{- if not .Values.webhooks.certManager }}
       caBundle: {{ template "caBundle" . }}
+      {{- end }}
       service:
-        namespace: {{ .Values.namespace }}
+        namespace: {{ .Release.Namespace }}
         name: {{ include "kube-enforcer.fullname" . }}
         path: "/mutate"
     timeoutSeconds: 5

--- a/kube-enforcer/templates/rolebinding.yaml
+++ b/kube-enforcer/templates/rolebinding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Values.roleBinding.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -10,4 +10,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}
-    namespace: {{ .Values.namespace }}
+    namespace: {{ .Release.Namespace }}

--- a/kube-enforcer/templates/service-account.yaml
+++ b/kube-enforcer/templates/service-account.yaml
@@ -8,7 +8,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 imagePullSecrets:
 {{- if not .Values.imageCredentials.name }}
 {{ template "imageCredentials_name" . }}
@@ -24,7 +24,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 imagePullSecrets:
 {{- if not .Values.imageCredentials.name }}
 {{ template "imageCredentials_name" . }}

--- a/kube-enforcer/templates/service.yaml
+++ b/kube-enforcer/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     role: {{ include "kube-enforcer.fullname" . }}
   name: {{ include "kube-enforcer.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - port: 443

--- a/kube-enforcer/templates/starboard-config.yaml
+++ b/kube-enforcer/templates/starboard-config.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: starboard
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 data:
   configAuditReports.scanner: Conftest
   conftest.imageRef: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/kube-enforcer/templates/validating-webhook.yaml
+++ b/kube-enforcer/templates/validating-webhook.yaml
@@ -1,19 +1,23 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ .Values.webhooks.validatingWebhook.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 webhooks:
   - name: imageassurance.aquasec.com
-    failurePolicy: {{ .Values.webhooks.failurePolicy }}  
+    failurePolicy: {{ .Values.webhooks.failurePolicy }}
+    sideEffects: "None"
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - operations: ["CREATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]
     clientConfig:
+      {{- if not .Values.webhooks.certManager }}
       caBundle: {{ template "caBundle" . }}
+      {{- end }}
       service:
-        namespace: {{ .Values.namespace }}
+        namespace: {{ .Release.Namespace }}
         name: {{ include "kube-enforcer.fullname" . }}
     timeoutSeconds: 5

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -7,10 +7,9 @@ imageCredentials:
   registry: "registry.aquasec.com" #REQUIRED only if create is true, for dockerhub - "index.docker.io/v1/"
   username: ""
   password: ""
-  email: "example@gmail.com"
 
-aqua_enable_cache: yes
-aqua_cache_expiration_period: "60"  # default value is 60 
+aqua_enable_cache: yes # Specify whether to enable/disable the cache by using "yes", "true", "no", "false" values.
+aqua_cache_expiration_period: 60 # default value is 60
 
 image:
   repository: kube-enforcer
@@ -20,9 +19,8 @@ image:
 nameOverride: "aqua-kube-enforcer"
 fullnameOverride: "aqua-kube-enforcer"
 
-namespace: "aqua"
+clusterName: ""   # Display a custom cluster name in the infrastructure tab of Aqua Enterprise
 logicalName: ""
-
 logLevel: ""
 
 # Set create to false if you want to use an existing secret for the kube-enforcer certs
@@ -33,12 +31,14 @@ certsSecret:
   serverKey: ""
 
 aquaSecret:
+  create: true
   name: aqua-kube-enforcer-token
 # Enter the enforcer token in "clear-text" format without quotes generated from the Console UI
   kubeEnforcerToken: 
 
-envs:
-  gatewayAddress: aqua-gateway-svc.aqua:8443 
+gateway:
+  address: aqua-gateway-svc.aqua
+  port: 8443
 
 
 serviceAccount:
@@ -57,7 +57,8 @@ roleBinding:
   name: aqua-kube-enforcer 
 
 webhooks:
-  caBundle: ""
+  caBundle: "" # this field is required unless you're using Kubernetes cert-manager (set the flag below to true)
+  certManager: false # set this field true if you're using cert-manager and don't need to pass a caBundle
   failurePolicy: Ignore
   validatingWebhook:
     name: kube-enforcer-admission-hook-config
@@ -73,7 +74,7 @@ container_securityContext: {}
 livenessProbe:
   tcpSocket:
     port: 8080
-  initialDelaySeconds: 60 
+  initialDelaySeconds: 60
   periodSeconds: 30
 
 readinessProbe:
@@ -164,8 +165,7 @@ starboard:
 
 kubeEnforcerAdvance:
   enable: false
-  clusterName: ""
-  clusterID: ""
+  nodeID: "envoy"
 
   envoy:
     image:
@@ -184,172 +184,173 @@ kubeEnforcerAdvance:
     livenessProbe: {}
     resources: {}
 
-    files:
-      envoy.yaml: |-
-        node:
-          cluster: {{ .Values.kubeEnforcerAdvance.clusterName | default "k8s" }}
-          id: {{ .Values.kubeEnforcerAdvance.clusterID }}
-
-        dynamic_resources:
-          cds_config:
-            path: /etc/aquasec/envoy/cds.yaml
-            initial_fetch_timeout: 0s
-          lds_config:
-            path: /etc/envoy/lds.yaml
-      lds.yaml: |-
-        resources:
-          - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
-            name: listener_0
-            address:
-              socket_address:
-                address: 0.0.0.0
-                port_value: 8443
-            filter_chains:
-              - filters:
-                  - name: envoy.filters.network.http_connection_manager
-                    typed_config:
-                      "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                      stream_idle_timeout: 0s
-                      drain_timeout: 20s
-                      access_log:
-                        - name: envoy.access_loggers.file
-                          typed_config:
-                            "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                            path: "/dev/stdout"
-                      codec_type: AUTO
-                      stat_prefix: ingress_https
-                      route_config:
-                        name: local_route
-                        virtual_hosts:
-                          - name: https
-                            domains:
-                              - "*"
-                            routes:
-                              - match:
-                                  prefix: "/agent_grpc_channel.GWChannelV2/PushNotificationHandler"
-                                  grpc: { }
-                                route:
-                                  cluster: aqua-kube-enforcer
-                                  timeout: 0s
-                              - match:
-                                  prefix: "/"
-                                  grpc: { }
-                                route:
-                                  cluster: aqua-gateway
-                                  timeout: 0s
-                              - match:
-                                  prefix: "/"
-                                route:
-                                  cluster: aqua-kube-enforcer-k8s
-                                  timeout: 0s
-
-                      http_filters:
-                        - name: envoy.filters.http.health_check
-                          typed_config:
-                            "@type": type.googleapis.com/envoy.config.filter.http.health_check.v2.HealthCheck
-                            pass_through_mode: false
-                            headers:
-                              - name: ":path"
-                                exact_match: "/healthz"
-                              - name: "x-envoy-livenessprobe"
-                                exact_match: "healthz"
-                        - name: envoy.filters.http.router
-                          typed_config: { }
-                transport_socket:
-                  name: envoy.transport_sockets.tls
-                  typed_config:
-                    "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
-                    common_tls_context:
-                      alpn_protocols: "h2,http/1.1"
-                      tls_certificates:
-                        - certificate_chain:
-                            filename: "/etc/ssl/envoy/server.crt"
-                          private_key:
-                            filename: "/etc/ssl/envoy/server.key"
-      cds.yaml: |-
-        resources:
-        - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
-          name: aqua-kube-enforcer
-          connect_timeout: 180s
-          type: STRICT_DNS
-          dns_lookup_family: V4_ONLY
-          lb_policy: ROUND_ROBIN
-          http2_protocol_options:
-            hpack_table_size: 4294967
-            max_concurrent_streams: 2147483647
-          circuit_breakers:
-            thresholds:
-              max_pending_requests: 2147483647
-              max_requests: 2147483647
-          load_assignment:
-            cluster_name: aqua-kube-enforcer
-            endpoints:
-              - lb_endpoints:
-                - endpoint:
-                    address:
-                      socket_address:
-                        address: localhost
-                        port_value: 8442
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              sni: aqua-kube-enforcer
-        - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
-          name: aqua-kube-enforcer-k8s
-          connect_timeout: 180s
-          type: STRICT_DNS
-          dns_lookup_family: V4_ONLY
-          lb_policy: ROUND_ROBIN
-          circuit_breakers:
-            thresholds:
-              max_pending_requests: 2147483647
-              max_requests: 2147483647
-          load_assignment:
-            cluster_name: aqua-kube-enforcer-k8s
-            endpoints:
-              - lb_endpoints:
-                - endpoint:
-                    address:
-                      socket_address:
-                        address: localhost
-                        port_value: 8449
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              sni: aqua-kube-enforcer-k8s
-        - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
-          name: aqua-gateway
-          connect_timeout: 180s
-          type: STRICT_DNS
-          dns_lookup_family: V4_ONLY
-          lb_policy: ROUND_ROBIN
-          http2_protocol_options:
-            hpack_table_size: 4294967
-            max_concurrent_streams: 2147483647
-          circuit_breakers:
-            thresholds:
-              max_pending_requests: 2147483647
-              max_requests: 2147483647
-          load_assignment:
-            cluster_name: aqua-gateway
-            endpoints:
-              - lb_endpoints:
-                - endpoint:
-                    address:
-                      socket_address:
-                        address: aqua-gateway.aqua
-                        port_value: 8443
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              sni: aqua-gateway
-      validation_context_sds_secret.yaml: |-
-        resources:
-          - "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"
-            name: "validation_context_sds"
-            validation_context:
-              trusted_ca:
-                filename: /etc/aquasec/envoy/ca-certificates.crt
+    ## Enabling this will replace any templated envoy configuration with the list of files passed below
+    custom_envoy_files: {}
+#      envoy.yaml: |-
+#        node:
+#          cluster: {{ .Values.kubeEnforcerAdvance.clusterName | default "k8s" }}
+#          id: {{ .Values.kubeEnforcerAdvance.clusterID }}
+#
+#        dynamic_resources:
+#          cds_config:
+#            path: /etc/aquasec/envoy/cds.yaml
+#            initial_fetch_timeout: 0s
+#          lds_config:
+#            path: /etc/envoy/lds.yaml
+#      lds.yaml: |-
+#        resources:
+#          - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+#            name: listener_0
+#            address:
+#              socket_address:
+#                address: 0.0.0.0
+#                port_value: 8443
+#            filter_chains:
+#              - filters:
+#                  - name: envoy.filters.network.http_connection_manager
+#                    typed_config:
+#                      "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+#                      stream_idle_timeout: 0s
+#                      drain_timeout: 20s
+#                      access_log:
+#                        - name: envoy.access_loggers.file
+#                          typed_config:
+#                            "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+#                            path: "/dev/stdout"
+#                      codec_type: AUTO
+#                      stat_prefix: ingress_https
+#                      route_config:
+#                        name: local_route
+#                        virtual_hosts:
+#                          - name: https
+#                            domains:
+#                              - "*"
+#                            routes:
+#                              - match:
+#                                  prefix: "/agent_grpc_channel.GWChannelV2/PushNotificationHandler"
+#                                  grpc: { }
+#                                route:
+#                                  cluster: aqua-kube-enforcer
+#                                  timeout: 0s
+#                              - match:
+#                                  prefix: "/"
+#                                  grpc: { }
+#                                route:
+#                                  cluster: aqua-gateway
+#                                  timeout: 0s
+#                              - match:
+#                                  prefix: "/"
+#                                route:
+#                                  cluster: aqua-kube-enforcer-k8s
+#                                  timeout: 0s
+#
+#                      http_filters:
+#                        - name: envoy.filters.http.health_check
+#                          typed_config:
+#                            "@type": type.googleapis.com/envoy.config.filter.http.health_check.v2.HealthCheck
+#                            pass_through_mode: false
+#                            headers:
+#                              - name: ":path"
+#                                exact_match: "/healthz"
+#                              - name: "x-envoy-livenessprobe"
+#                                exact_match: "healthz"
+#                        - name: envoy.filters.http.router
+#                          typed_config: { }
+#                transport_socket:
+#                  name: envoy.transport_sockets.tls
+#                  typed_config:
+#                    "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+#                    common_tls_context:
+#                      alpn_protocols: "h2,http/1.1"
+#                      tls_certificates:
+#                        - certificate_chain:
+#                            filename: "/etc/ssl/envoy/server.crt"
+#                          private_key:
+#                            filename: "/etc/ssl/envoy/server.key"
+#      cds.yaml: |-
+#        resources:
+#        - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+#          name: aqua-kube-enforcer
+#          connect_timeout: 180s
+#          type: STRICT_DNS
+#          dns_lookup_family: V4_ONLY
+#          lb_policy: ROUND_ROBIN
+#          http2_protocol_options:
+#            hpack_table_size: 4294967
+#            max_concurrent_streams: 2147483647
+#          circuit_breakers:
+#            thresholds:
+#              max_pending_requests: 2147483647
+#              max_requests: 2147483647
+#          load_assignment:
+#            cluster_name: aqua-kube-enforcer
+#            endpoints:
+#              - lb_endpoints:
+#                - endpoint:
+#                    address:
+#                      socket_address:
+#                        address: localhost
+#                        port_value: 8442
+#          transport_socket:
+#            name: envoy.transport_sockets.tls
+#            typed_config:
+#              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+#              sni: aqua-kube-enforcer
+#        - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+#          name: aqua-kube-enforcer-k8s
+#          connect_timeout: 180s
+#          type: STRICT_DNS
+#          dns_lookup_family: V4_ONLY
+#          lb_policy: ROUND_ROBIN
+#          circuit_breakers:
+#            thresholds:
+#              max_pending_requests: 2147483647
+#              max_requests: 2147483647
+#          load_assignment:
+#            cluster_name: aqua-kube-enforcer-k8s
+#            endpoints:
+#              - lb_endpoints:
+#                - endpoint:
+#                    address:
+#                      socket_address:
+#                        address: localhost
+#                        port_value: 8449
+#          transport_socket:
+#            name: envoy.transport_sockets.tls
+#            typed_config:
+#              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+#              sni: aqua-kube-enforcer-k8s
+#        - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+#          name: aqua-gateway
+#          connect_timeout: 180s
+#          type: STRICT_DNS
+#          dns_lookup_family: V4_ONLY
+#          lb_policy: ROUND_ROBIN
+#          http2_protocol_options:
+#            hpack_table_size: 4294967
+#            max_concurrent_streams: 2147483647
+#          circuit_breakers:
+#            thresholds:
+#              max_pending_requests: 2147483647
+#              max_requests: 2147483647
+#          load_assignment:
+#            cluster_name: aqua-gateway
+#            endpoints:
+#              - lb_endpoints:
+#                - endpoint:
+#                    address:
+#                      socket_address:
+#                        address: aqua-gateway.aqua
+#                        port_value: 8443
+#          transport_socket:
+#            name: envoy.transport_sockets.tls
+#            typed_config:
+#              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+#              sni: aqua-gateway
+#      validation_context_sds_secret.yaml: |-
+#        resources:
+#          - "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"
+#            name: "validation_context_sds"
+#            validation_context:
+#              trusted_ca:
+#                filename: /etc/aquasec/envoy/ca-certificates.crt

--- a/scanner/README.md
+++ b/scanner/README.md
@@ -79,6 +79,7 @@ Parameter | Description | Default| Mandatory
 `repositoryUriPrefix` | repository uri prefix for dockerhub set `docker.io` | `registry.aquasec.com`| `YES` 
 `dockerSocket.mount` | boolean parameter if to mount docker socket | `unset`| `NO` 
 `dockerSocket.path` | docker socket path | `/var/run/docker.sock`| `NO` 
+`directCC.enabled` | scanner talk to the cybercenter directly | `yes`| `NO` 
 `serviceAccount.create` | Enable to create serviceaccount if not exist in the k8s | `false`| `NO`
 `serviceAccount.name` | K8 service-account name either existing one or new name if create is enabled | `aqua-sa`  | `YES`
 `server.scheme` | scheme for server to connect | `http`| `NO`

--- a/scanner/templates/image-pull-secret.yaml
+++ b/scanner/templates/image-pull-secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.imageCredentials.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/scanner/templates/scanner-deployment.yaml
+++ b/scanner/templates/scanner-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-scanner
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-scanner
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -47,7 +48,9 @@ spec:
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         args:
         - daemon
+        {{- if .Values.directCC.enabled }}
         - --direct-cc
+        {{- end }}
         - --user
         {{- if .Values.scannerUserSecret.enable }}
         - "$(SCANNER_USER)"

--- a/scanner/templates/service-account.yaml
+++ b/scanner/templates/service-account.yaml
@@ -7,6 +7,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/scanner/values.yaml
+++ b/scanner/values.yaml
@@ -11,6 +11,9 @@ dockerSock:
   mount: # put true for mount docker socket.
   path: /var/run/docker.sock # pks - /var/vcap/data/sys/run/docker/docker.sock
 
+directCC:
+  enabled: true     # Change it to false if the scanners don't connect directly to CyberCenter but only console does
+
 serviceAccount:
   create: false     #Change it to false if the cluster doesn't consists aqua service account
   name: "aqua-sa"   #Mention the Service Account name, Default "aqua-sa"

--- a/server/templates/db-deployment.yaml
+++ b/server/templates/db-deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-database
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-database
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -127,6 +128,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-audit-database
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-audit-database
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -141,6 +143,11 @@ spec:
       annotations:
       {{- if and (.Values.db.tolerations) (semverCompare "<1.6-0" .Capabilities.KubeVersion.GitVersion) }}
         scheduler.alpha.kubernetes.io/tolerations: '{{ toJson .Values.db.tolerations }}'
+      {{- end }}
+      {{- with .Values.db.podAnnotations }}
+      {{- range $key,$value := . }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
       {{- end }}
       labels:
         app: {{ .Release.Name }}-audit-database

--- a/server/templates/db-password-secret.yaml
+++ b/server/templates/db-password-secret.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-database-password
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-database
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -29,6 +30,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-database-password
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-database
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/db-pvc.yaml
+++ b/server/templates/db-pvc.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-database-pvc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -22,6 +23,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-audit-database-pvc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/db-service.yaml
+++ b/server/templates/db-service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-database-svc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-database
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -20,6 +21,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-audit-database-svc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-audit-database
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/envoy-config.yaml
+++ b/server/templates/envoy-config.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-envoy-conf
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-envoy
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/envoy-deployment.yaml
+++ b/server/templates/envoy-deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-envoy
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-envoy
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/envoy-service.yaml
+++ b/server/templates/envoy-service.yaml
@@ -7,6 +7,7 @@ metadata:
   finalizers:
   - service.kubernetes.io/load-balancer-cleanup
   name: aqua-lb
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-envoy
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/gate-deployment.yaml
+++ b/server/templates/gate-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-gateway
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-gateway
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/gate-headless-service.yaml
+++ b/server/templates/gate-headless-service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-gateway-headless-svc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-gateway
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/gate-service.yaml
+++ b/server/templates/gate-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-gateway-svc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-gateway
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/image-pull-secret.yaml
+++ b/server/templates/image-pull-secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Namespace }}-registry-secret
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/serviceaccount.yaml
+++ b/server/templates/serviceaccount.yaml
@@ -7,6 +7,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
   name: {{ .Release.Namespace }}-sa
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/web-deployment.yaml
+++ b/server/templates/web-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-console
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-console
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/web-ingress.yaml
+++ b/server/templates/web-ingress.yaml
@@ -11,6 +11,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-console-ingress
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-console-ingress
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/server/templates/web-secrets.yaml
+++ b/server/templates/web-secrets.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-console-secrets
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-console
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/server/templates/web-service.yaml
+++ b/server/templates/web-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-console-svc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-console
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/tenant-manager/templates/db-deployment.yaml
+++ b/tenant-manager/templates/db-deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-tm-db
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-tm-db
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/tenant-manager/templates/db-password-secret.yaml
+++ b/tenant-manager/templates/db-password-secret.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-tm-db-password
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-tm-db
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -26,6 +27,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-tm-db-password
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-tm-db
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/tenant-manager/templates/db-pvc.yaml
+++ b/tenant-manager/templates/db-pvc.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-tm-db-pvc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/tenant-manager/templates/db-service.yaml
+++ b/tenant-manager/templates/db-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-tm-db-svc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-tm-db
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/tenant-manager/templates/image-pull-secret.yaml
+++ b/tenant-manager/templates/image-pull-secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.imageCredentials.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/tenant-manager/templates/serviceaccount.yaml
+++ b/tenant-manager/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}-sa
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/tenant-manager/templates/tm-deploy.yaml
+++ b/tenant-manager/templates/tm-deploy.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-tenantmanager
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-tenantmanager
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/tenant-manager/templates/tm-secrets.yaml
+++ b/tenant-manager/templates/tm-secrets.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-tenantmanager-secrets
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-tenantmanager
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/tenant-manager/templates/tm-service.yaml
+++ b/tenant-manager/templates/tm-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-tenantmanager
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-tenantmanager
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"


### PR DESCRIPTION
Scanner:

making direct-cc option available in the values
KE:

CLUSTER_NAME: making option available in the values outside advanced envoy configuration (users may want to use it without necessarily enabling envoy)
CLUSTER_NAME: default value can stay empty, it'll use cluster ID
CLUSTER_NAME: default value for envoy stays set to k8s if not cluster name is passed

------
noticed that we used 3 standards, listed below in order of frequency (most used -> least used)

no namespace defined in templates
namespace: {{ .Release.Namespace }}
namespace: {{ .Values.namespace }}
I refactored all the templates with the option 2.: namespace: {{ .Release.Namespace }}

It is a good standard and easy to manage without extra values.

UPDATE
As part of this refactoring:

templated the envoy configurations to use parameters in the values
changed the 'clusterName' and 'nodeID' values to mandatory (since they are) with defaults to avoid invalid configuration
added 'create' option for aquaSecret creation in ke-starboard as for ke chart
removed a few unused options left in values.yaml

---
Add annotations to audit database. Fixes #355

Small change so I did not test it, the code is literally copied from operational database.