### PR TITLE
6.2 | Fix | Server, KE, KE-starboard | Replaced Envoy deprecated API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 .vscode/
+*.iml

--- a/kube-enforcer-starboard/conf/lds.yaml.tpl
+++ b/kube-enforcer-starboard/conf/lds.yaml.tpl
@@ -45,9 +45,9 @@ resources:
                           timeout: 0s
 
               http_filters:
-                - name: envoy.filters.http.health_check
+                - name: envoy.extensions.filters.http.health_check
                   typed_config:
-                    "@type": type.googleapis.com/envoy.config.filter.http.health_check.v2.HealthCheck
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
                     pass_through_mode: false
                     headers:
                       - name: ":path"

--- a/kube-enforcer/conf/lds.yaml.tpl
+++ b/kube-enforcer/conf/lds.yaml.tpl
@@ -45,9 +45,9 @@ resources:
                           timeout: 0s
 
               http_filters:
-                - name: envoy.filters.http.health_check
+                - name: envoy.extensions.filters.http.health_check
                   typed_config:
-                    "@type": type.googleapis.com/envoy.config.filter.http.health_check.v2.HealthCheck
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
                     pass_through_mode: false
                     headers:
                       - name: ":path"

--- a/server/conf/envoy.yaml.tpl
+++ b/server/conf/envoy.yaml.tpl
@@ -31,9 +31,9 @@ static_resources:
                   cluster: aqua-gateway-svc
                   timeout: 0s
           http_filters:
-          - name: envoy.filters.http.health_check
+          - name: envoy.extensions.filters.http.health_check
             typed_config:
-              "@type": type.googleapis.com/envoy.config.filter.http.health_check.v2.HealthCheck
+              "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
               pass_through_mode: false
               headers:
               - name: ":path"


### PR DESCRIPTION
This change affects the use of the following API in the Envoy configurations of Server, Kube-Enforcer and Kube-Enforecer starboard charts:

- **old**: config.filter.http.health_check.v2.HealthCheck
- **new**: extensions.filters.http.health_check.v3.HealthCheck