### PR TITLE
ingresses: add pathType

### DIFF
--- a/aqua-quickstart/templates/web-ingress.yaml
+++ b/aqua-quickstart/templates/web-ingress.yaml
@@ -28,6 +28,7 @@ spec:
         http:
           paths:
             - path: /
+              pathType: Prefix
               backend:
                 serviceName: {{ $fullname }}-console-svc
                 servicePort: {{ $servicePort }}

--- a/examples/ingress-example.yaml
+++ b/examples/ingress-example.yaml
@@ -14,6 +14,7 @@ spec:
           serviceName: aqua-console-svc
           servicePort: 8080
         path: /
+        pathType: Prefix
 status:
   loadBalancer:
     ingress:

--- a/server/templates/web-ingress.yaml
+++ b/server/templates/web-ingress.yaml
@@ -2,6 +2,7 @@
 {{- $fullname := .Release.Name -}}
 {{- $servicePort := (index .Values.web.service.ports 0).port -}}
 {{- $ingressPath := .Values.web.ingress.path -}}
+{{- $ingressPathType := .Values.web.ingress.pathType -}}
 ---
 {{- if (semverCompare ">= 1.14" .Capabilities.KubeVersion.GitVersion) }}
 apiVersion: networking.k8s.io/v1beta1
@@ -29,6 +30,7 @@ spec:
         http:
           paths:
             - path: {{ $ingressPath }}
+              pathType: {{ $ingressPathType }}
               backend:
                 serviceName: {{ $fullname }}-console-svc
                 servicePort: {{ $servicePort }}

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -253,6 +253,7 @@ web:
     hosts: #REQUIRED
     # - aquasec-test.example.com
     path: /
+    pathType: Prefix
     tls: []
     #  - secretName: aquasec-tls
     #    hosts:


### PR DESCRIPTION
On Ingresses `PathType` are set to  `ImplementationSpecific` by default.
Path like "/" may not work with some ingress controllers which would expect "/*" instead.
This MR set the `PathType` to `Prefix` to fix this.