### PR TITLE
6.5 | Fix | Envoy | No Load-balancer finalizer for non-LoadBalancer service type

### DIFF
--- a/server/templates/envoy-service.yaml
+++ b/server/templates/envoy-service.yaml
@@ -1,11 +1,11 @@
-
 {{- if .Values.envoy.enabled }}
-
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if eq .Values.envoy.service.type "LoadBalancer" }}
   finalizers:
-  - service.kubernetes.io/load-balancer-cleanup
+    - service.kubernetes.io/load-balancer-cleanup
+  {{- end }}
   name: aqua-lb
   namespace: {{ .Release.Namespace }}
   labels:


### PR DESCRIPTION
The load balancer finaliser installed in the Envoy service shouldn't be there if the service type is either NodePort or ClusterIP for th Envoy. This causes the deletion of the service to be pending since there is not loadbalancer created.