### PR TITLE
6.5 | updating to latest starboard image

### DIFF
--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -112,7 +112,7 @@ starboard:
   image:
     repositoryUriPrefix: "docker.io/aquasec"
     repository: "starboard-operator"
-    tag: "0.12.0-rc3"
+    tag: "0.12.0"
     pullPolicy: IfNotPresent
 
   container_securityContext:


### PR DESCRIPTION
New version for starboard is released https://github.com/aquasecurity/starboard/releases/tag/v0.12.0

