### PR TITLE
6.5 | enforcer | fixing readiness/liveness probes

### DIFF
--- a/enforcer/README.md
+++ b/enforcer/README.md
@@ -149,6 +149,7 @@ Parameter | Description | Default| Mandatory
 `image.repository` | the docker image name to use | `enforcer`| `YES`
 `image.tag` | The image tag to use. | `6.5`| `YES`
 `image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`| `NO`
+`healthMonitor.enabled` | Enabling health monitoring for enforcer liveness and readiness | `true` | `YES`
 `resources` |	Resource requests and limits | `{}`| `NO`
 `nodeSelector` |	Kubernetes node selector	| `{}`| `NO`
 `tolerations` |	Kubernetes node tolerations	| `[]`| `NO`

--- a/enforcer/templates/enforcer-configmap.yaml
+++ b/enforcer/templates/enforcer-configmap.yaml
@@ -11,14 +11,14 @@ data:
   {{- else }}
   AQUA_SERVER: {{ .Values.gate.host | default "aqua-gateway-svc" }}:{{ .Values.gate.port | default "8443" }}
   {{- end }}
-  AQUA_INSTALL_PATH: /var/lib/aquasec
+  AQUA_INSTALL_PATH: "/var/lib/aquasec"
   {{- if .Values.enforcerLogicalName }}
   AQUA_LOGICAL_NAME: {{ .Values.enforcerLogicalName }}
   {{- else }}
   AQUA_LOGICAL_NAME: {{ .Release.Name }}-helm
   {{- end }}
   {{- if .Values.hostRunPath }}
-  AQUA_HOST_RUN_PATH: {{ .Values.hostRunPath }}
+  AQUA_HOST_RUN_PATH: {{ .Values.hostRunPath | quote }}
   {{- end }}
   {{- if .Values.TLS.enabled }}
   AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/key.pem"
@@ -28,3 +28,4 @@ data:
   {{- end }}
   AQUA_TLS_VERIFY: {{ .Values.TLS.tls_verify | quote }}
   {{- end }}
+  AQUA_HEALTH_MONITOR_ENABLED: {{ .Values.healthMonitor.enabled | quote }}

--- a/enforcer/templates/enforcer-daemonset.yaml
+++ b/enforcer/templates/enforcer-daemonset.yaml
@@ -87,6 +87,7 @@ spec:
           name: aquasec-audit
         - mountPath: /data
           name: aquasec-data
+{{- if .Values.healthMonitor.enabled }}
 {{- with .Values.livenessProbe }}
         livenessProbe:
 {{ toYaml . | indent 10 }}
@@ -94,6 +95,7 @@ spec:
 {{- with .Values.readinessProbe }}
         readinessProbe:
 {{ toYaml . | indent 10 }}
+{{- end }}
 {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/enforcer/values.yaml
+++ b/enforcer/values.yaml
@@ -72,6 +72,9 @@ image:
   tag: "6.5"
   pullPolicy: IfNotPresent
 
+healthMonitor:
+  enabled: "true"
+
 livenessProbe:
   httpGet:
     path: /healthz

--- a/kube-enforcer/templates/kube-enforcer-configmap.yaml
+++ b/kube-enforcer/templates/kube-enforcer-configmap.yaml
@@ -5,18 +5,18 @@ metadata:
   name: {{ .Release.Name }}-kube-enforcer-config
   namespace: {{ .Release.Namespace }}
 data:
-  SCALOCK_LOG_LEVEL: "{{ .Values.logLevel | default "DEBUG" }}"
-  AQUA_ENABLE_CACHE: "{{ .Values.aqua_enable_cache }}"
-  AQUA_CACHE_EXPIRATION_PERIOD: "{{ .Values.aqua_cache_expiration_period | default "60"}}"
-  AQUA_LOGICAL_NAME: "{{ .Values.logicalName }}"
-  CLUSTER_NAME: "{{ .Values.clusterName }}"
+  SCALOCK_LOG_LEVEL: {{ .Values.logLevel | default "INFO" | quote }}
+  AQUA_ENABLE_CACHE: {{ .Values.aqua_enable_cache | quote }}
+  AQUA_CACHE_EXPIRATION_PERIOD: {{ .Values.aqua_cache_expiration_period | default "60" | quote }}
+  AQUA_LOGICAL_NAME: {{ .Values.logicalName | quote }}
+  CLUSTER_NAME: {{ .Values.clusterName | quote }}
   TLS_SERVER_CERT_FILEPATH: "/certs/server.crt"
   TLS_SERVER_KEY_FILEPATH: "/certs/server.key"
 # mTLS env config
 {{- if .Values.TLS.enabled }}
   AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/key.pem"
   AQUA_PUBLIC_KEY: "/opt/aquasec/ssl/cert.pem"
-  AQUA_TLS_VERIFY: "{{ .Values.TLS.tls_verify | quote }}"
+  AQUA_TLS_VERIFY: {{ .Values.TLS.tls_verify | quote }}
 {{- if .Values.TLS.rootCA_fileName }}
   AQUA_ROOT_CA: "/opt/aquasec/ssl/ca.pem"
 {{- end }}


### PR DESCRIPTION
1. Enforcer - fixing readiness and liveness probes failure due to env AQUA_HEALTH_MONITOR_ENABLED missing.
2. KE - fixing double quotes in templates