### PR TITLE
6.5 | Server | Fix | Web Ingress pathType fix

### DIFF
--- a/server/templates/web-ingress.yaml
+++ b/server/templates/web-ingress.yaml
@@ -4,7 +4,7 @@
 {{- $ingressPath := .Values.web.ingress.path -}}
 {{- $pathType := .Values.web.ingress.pathType -}}
 ---
-{{- if (semverCompare ">= 1.14" .Capabilities.KubeVersion.GitVersion) }}
+{{- if (semverCompare ">= 1.14, <=1.21" .Capabilities.KubeVersion.GitVersion) }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
 apiVersion: extensions/v1beta1

--- a/server/templates/web-ingress.yaml
+++ b/server/templates/web-ingress.yaml
@@ -2,6 +2,7 @@
 {{- $fullname := .Release.Name -}}
 {{- $servicePort := (index .Values.web.service.ports 0).port -}}
 {{- $ingressPath := .Values.web.ingress.path -}}
+{{- $pathType := .Values.web.ingress.pathType -}}
 ---
 {{- if (semverCompare ">= 1.14" .Capabilities.KubeVersion.GitVersion) }}
 apiVersion: networking.k8s.io/v1beta1
@@ -29,7 +30,7 @@ spec:
         http:
           paths:
             - path: {{ $ingressPath }}
-              pathType: {{ .Values.web.ingress.pathType }}
+              pathType: {{ $pathType }}
               backend:
                 serviceName: {{ $fullname }}-console-svc
                 servicePort: {{ $servicePort }}


### PR DESCRIPTION
Fix web-ingress template with pathType value declared as variable as used in the range.
Limit the use of networking.k8s.io/v1beta1 to Kubernetes versions 1.14 - 1.21