### PR TITLE
6.5 | Server | Fix | Gateway headless service required by Envoy

### DIFF
--- a/server/templates/gateway-headless-service.yaml
+++ b/server/templates/gateway-headless-service.yaml
@@ -1,0 +1,31 @@
+{{- if and (.Values.envoy.enabled) (.Values.gateway.enabled) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-gateway-headless-svc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-gateway
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  clusterIP: None
+  type: ClusterIP
+  selector:
+    app: {{ .Release.Name }}-gateway
+  ports:
+  {{- range $port := .Values.gateway.service.ports }}
+  - name: {{ $port.name }}
+    port: {{ $port.port }}
+    targetPort: {{ $port.targetPort }}
+    {{- if $port.nodePort }}
+    nodePort: {{ $port.nodePort }}
+    {{- end }}
+    {{- if $port.protocol }}
+    protocol: {{ $port.protocol }}
+    {{- end }}
+  {{- end }}
+
+{{- end }}


### PR DESCRIPTION
When enabling Envoy and Gateway components from the chart, a headless gateway service is required to be deployed

This service is used by Envoy to gain visibility over all the gateway replicas and establish GRPC connection to them