### PR TITLE
corract serviceAccount Value

### DIFF
--- a/enforcer/templates/enforcer-daemonset.yaml
+++ b/enforcer/templates/enforcer-daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         app: {{ .Release.Name }}-ds
       name: {{ .Release.Name }}-ds
     spec:
-      serviceAccount: {{ .Values.serviceAccount.name }}
+      serviceAccount: {{ .Release.Namespace }}-sa
       hostPID: true
       containers:
       - name: enforcer


### PR DESCRIPTION
changed serviceAccount to value which will be used in ServiceAccount Template. DaemonSet never would be created because of missing SA