### PR TITLE
6.5 | RBAC fixing && default to non-privileged mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode/
 server/charts
 server/subcharts
-server/*.lock
+server/Chart.lock
+*.lock
 *.tgz
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 server/charts
 server/subcharts
 server/*.lock
+*.tgz
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ This repository includes the following charts; they can be deployed separately:
 
 | Chart | Description | Latest Chart Version |
 |---|---|---|
-| [Server](server/) | Deploys the Console, Database, and Gateway components; optionally deploys Envoy component | 6.5.8 |
-| [Enforcer](enforcer/) | Deploys the Aqua Enforcer daemonset | 6.5.4 |
+| [Server](server/) | Deploys the Console, Database, and Gateway components; optionally deploys Envoy component | 6.5.9 |
+| [Enforcer](enforcer/) | Deploys the Aqua Enforcer daemonset | 6.5.5 |
 | [Scanner](scanner/)  | Deploys the Aqua Scanner deployment | 6.5.3 |
 | [KubeEnforcer](kube-enforcer/)| Deploys Aqua KubeEnforcer | 6.5.2 |
-| [Gateway](gateway)| Deploys the Aqua Standalone Gateway | 6.5.4 |
-| [Tenant-Manager](tenant-manager/)| Deploys the Aqua Tenant Manager | 6.5.0 |
+| [Gateway](gateway)| Deploys the Aqua Standalone Gateway | 6.5.5 |
+| [Tenant-Manager](tenant-manager/)| Deploys the Aqua Tenant Manager | 6.5.1 |
 | [Cyber Center](cyber-center/)| Deploys Aqua CyberCenter offline for air-gap environment| 6.5.0 |
 | [Cloud Connector](cloud-connector/) | Deploys the Aqua Cloud Connector | 6.5.2 |
 | [QuickStart](aqua-quickstart/ )| Not for production use (see [below](#quick-start-deployment-not-for-production-purposes)). Deploys the Console, Database, Gateway and KubeEnforcer components | 6.5.2 |
@@ -77,12 +77,12 @@ helm search repo aqua-helm --version 6.5
 Example output:
 ```csv
 NAME                            CHART VERSION       APP VERSION         DESCRIPTION
-aqua-helm/server                    6.5.8               6.5                 A Helm chart for the Aqua Console components
-aqua-helm/enforcer                  6.5.4               6.5                 A Helm chart for the Aqua Enforcer
+aqua-helm/server                    6.5.9               6.5                 A Helm chart for the Aqua Console components
+aqua-helm/enforcer                  6.5.5               6.5                 A Helm chart for the Aqua Enforcer
 aqua-helm/kube-enforcer             6.5.2               6.5                 A Helm chart for the Aqua KubeEnforcer
 aqua-helm/scanner                   6.5.3               6.5                 A Helm chart for the Aqua Scanner CLI component
-aqua-helm/gateway                   6.5.4               6.5                 A Helm chart for the Aqua Gateway
-aqua-helm/tenant-manager            6.5.0               6.5                 A Helm chart for the Aqua Tenant Manager
+aqua-helm/gateway                   6.5.5               6.5                 A Helm chart for the Aqua Gateway
+aqua-helm/tenant-manager            6.5.1               6.5                 A Helm chart for the Aqua Tenant Manager
 aqua-helm/cyber-center              6.5.0               6.5                 A Helm chart for Aqua CyberCenter
 aqua-helm/cloud-connector           6.5.2               6.5                 A Helm chart for Aqua Cloud-Connector
 ```

--- a/enforcer/CHANGELOG.md
+++ b/enforcer/CHANGELOG.md
@@ -1,8 +1,10 @@
-## 6.5.4 ( December 8, 2021 )
+## 6.5.5 ( December 14th)
+* Add AQUA_LOGICAL_NAME and AQUA_NODE_NAME
+## 6.5.4 ( December 8th, 2021 )
 * Adding capabilities for Behavioral detection
 * Making enforcer deployment default to non-privilege mode
 * Updating Readme
-## 6.5.3 ( December 6, 2021 )
+## 6.5.3 ( December 6th, 2021 )
 * Update service account name - [447](https://github.com/aquasecurity/aqua-helm/pull/447)
 ## 6.5.2 ( November 24th, 2021 )
 * Added separate config map for Enforcer chart and updated template with annotations for configmap checksum - [401](https://github.com/aquasecurity/aqua-helm/pull/401)

--- a/enforcer/CHANGELOG.md
+++ b/enforcer/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 6.5.5 ( December 14th)
-* Add AQUA_LOGICAL_NAME and AQUA_NODE_NAME
+* Add AQUA_LOGICAL_NAME and AQUA_NODE_NAME - [454](https://github.com/aquasecurity/aqua-helm/pull/454)
 ## 6.5.4 ( December 8th, 2021 )
 * Adding capabilities for Behavioral detection
 * Making enforcer deployment default to non-privilege mode

--- a/enforcer/Chart.yaml
+++ b/enforcer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "6.5"
 description: A Helm chart for the Aqua Enforcer
 name: enforcer
-version: "6.5.4"
+version: "6.5.5"
 icon: https://avatars3.githubusercontent.com/u/12783832?s=200&v=4
 home: https://www.aquasec.com/
 maintainers:

--- a/enforcer/README.md
+++ b/enforcer/README.md
@@ -144,7 +144,8 @@ Parameter | Description | Default| Mandatory
 `enforcerToken` | enforcer token value | `enforcer-token`| `YES`
 `enforcerTokenSecretName` | enforcer token secret name if exists | `null`| `NO`
 `enforcerTokenSecretKey` | enforcer token secret key if exists | `null`| `NO`
-`enforcerLogicalName` | Specify the Logical Name the Aqua Enforcer will register under. if not specify the name will be `<Helm Release>-helm` | `unset`| `NO`
+`logicalName` | Specify the Logical Name the Aqua Enforcer will register under. if not specify the name will be `spec.nodeName` | `unset`| `NO`
+`nodelName` | Specify the Node Name the Aqua Enforcer will register under. if not specify the name will be `spec.nodeName` | `unset`| `NO`
 `securityContext.privileged` | determines if any container in a pod can enable privileged mode. | `false`| `NO`
 `securityContext.capabilities` | Linux capabilities provide a finer grained breakdown of the privileges traditionally associated with the superuser. | `add {}`| `NO`
 `hostRunPath` |	for changing host run path for example for pks need to change to /var/vcap/sys/run/docker	| `unset`| `NO`

--- a/enforcer/templates/enforcer-configmap.yaml
+++ b/enforcer/templates/enforcer-configmap.yaml
@@ -12,11 +12,6 @@ data:
   AQUA_SERVER: {{ .Values.gate.host | default "aqua-gateway-svc" }}:{{ .Values.gate.port | default "8443" }}
   {{- end }}
   AQUA_INSTALL_PATH: "/var/lib/aquasec"
-  {{- if .Values.enforcerLogicalName }}
-  AQUA_LOGICAL_NAME: {{ .Values.enforcerLogicalName }}
-  {{- else }}
-  AQUA_LOGICAL_NAME: {{ .Release.Name }}-helm
-  {{- end }}
   {{- if .Values.hostRunPath }}
   AQUA_HOST_RUN_PATH: {{ .Values.hostRunPath | quote }}
   {{- end }}

--- a/enforcer/templates/enforcer-daemonset.yaml
+++ b/enforcer/templates/enforcer-daemonset.yaml
@@ -45,9 +45,21 @@ spec:
             name: {{ .Release.Name }}-enforcer-config
         env:
         - name: AQUA_NODE_NAME
+        {{- if .Values.nodeName }}
+          value: {{ .Values.nodeName }}
+        {{- else }}
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        {{- end }}
+        - name: AQUA_LOGICAL_NAME
+        {{- if .Values.logicalName }}
+          value: {{ .Values.logicalName }}
+        {{- else }}
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        {{- end }}
         {{- if .Values.enforcerTokenSecretName }}
         - name: AQUA_TOKEN
           valueFrom:
@@ -179,3 +191,7 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
   {{ end }}
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate

--- a/enforcer/templates/rbac.yaml
+++ b/enforcer/templates/rbac.yaml
@@ -1,3 +1,6 @@
+{{- if not .Values.platform -}}
+{{ template "platform" .}}
+{{- end }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -16,6 +19,11 @@ rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["*"]
   verbs: ["get", "list", "watch"]
+{{- if eq .Values.platform "openshift" }}
+- apiGroups: [""]
+  resources: ["imagestreams", "imagestreams/layers"]
+  verbs: ["get", "list", "watch"]
+{{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -39,16 +47,13 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}
     namespace: {{ .Release.Namespace }}
-{{- if not .Values.platform -}}
-{{ template "platform" .}}
-
-## Openshift RBAC
-{{- else if eq .Values.platform "openshift" }}
 ---
+## Openshift RBAC
+{{- if eq .Values.platform "openshift" }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: cluster-reader
+  name: {{ .Release.Name }}-cluster-reader
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}
@@ -94,7 +99,7 @@ metadata:
       but allows users to run with any non-root UID and access hostPath. The user must
       specify the UID or it must be specified on the by the manifest of the container runtime.
     release.openshift.io/create-only: "true"
-  name: aqua-scc
+  name: {{ .Release.Name }}-scc
 priority: null
 readOnlyRootFilesystem: false
 requiredDropCapabilities: null
@@ -114,9 +119,10 @@ volumes:
 - projected
 - secret
 - hostPath
+{{- end }}
 
 ## TKG RBAC
-{{- else if eq .Values.platform "tkg" }}
+{{- if eq .Values.platform "tkg" }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/enforcer/values.yaml
+++ b/enforcer/values.yaml
@@ -30,7 +30,9 @@ enforcerToken: enforcer-token
 
 enforcerTokenSecretName: null
 enforcerTokenSecretKey: null
-enforcerLogicalName: 
+
+logicalName:
+nodeName:
 
 logLevel:
 
@@ -54,6 +56,7 @@ securityContext:
       - CAP_SYS_ADMIN
       - CAP_IPC_LOCK
       - CAP_SYS_PTRACE
+
 hostRunPath: # pks - /var/vcap/sys/run/docker
 
 multiple_gateway: # enable this to connect enforcer with multiple gateways

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,6 +1,10 @@
-## 6.5.4 ( December 2, 2021 )
+## 6.5.5 ( December 14th, 2021)
+* Update RBAC | default to non-privilege mode and remove capabilities in openshift SCC
+* Add gateway service label support
+
+## 6.5.4 ( December 2nd, 2021 )
 * Move platform variable to global scope - [444](https://github.com/aquasecurity/aqua-helm/pull/444)
-## 6.5.3 ( December 2, 2021 )
+## 6.5.3 ( December 2nd, 2021 )
 * Add gateway headless service - [436](https://github.com/aquasecurity/aqua-helm/pull/436)
 ## 6.5.2 ( November 24th, 2021 )
 * Updated gateway chart to support deployment as a dependency chart - [412](https://github.com/aquasecurity/aqua-helm/pull/412)

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 6.5.5 ( December 14th, 2021)
-* Update RBAC | default to non-privilege mode and remove capabilities in openshift SCC
-* Add gateway service label support
+* Update RBAC | default to non-privilege mode and remove capabilities in openshift SCC - [454](https://github.com/aquasecurity/aqua-helm/pull/454)
+* Add gateway service label support - [454](https://github.com/aquasecurity/aqua-helm/pull/454)
 
 ## 6.5.4 ( December 2nd, 2021 )
 * Move platform variable to global scope - [444](https://github.com/aquasecurity/aqua-helm/pull/444)

--- a/gateway/Chart.yaml
+++ b/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "6.5"
 description: A Helm chart for the Aqua Gateway
 name: gateway
-version: "6.5.4"
+version: "6.5.5"
 icon: https://avatars3.githubusercontent.com/u/12783832?s=200&v=4
 home: https://www.aquasec.com/
 maintainers:

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -98,9 +98,8 @@ Parameter | Description | Default | Mandatory |
 `imageCredentials.registry` | set the registry url for dockerhub set `index.docker.io/v1/` | `registry.aquasec.com` | `YES`
 `imageCredentials.username` | Your Docker registry (DockerHub, etc.) username | `aqua-registry-secret` | `YES`
 `imageCredentials.password` | Your Docker registry (DockerHub, etc.) password | `unset` | `YES`
-`rbac.enabled` | if to create rbac configuration for aqua | `true` | `YES`
-`rbac.privileged` | determines if any container in a pod can enable privileged mode. | `true` | `YES`
-`rbac.roleRef` | name of rbac role to set in not create by helm | `unset` | `NO`
+`rbac.create` | To create RBAC for gateway component | `false` | `YES` <br />`if gateway alone is deploying in new cluster` 
+`clusterRole.roleRef` | cluster role reference name for cluster rolebinding | `unset` | `NO`
 `console.publicIP` | Address of the server | `aqua-console-svc` | `YES`
 `console.publicPort` | Server endpoint Port value  | `443` | `YES`
 `serviceAccount.name` | name of the ServiceAccount | `aqua-sa` | `YES`

--- a/gateway/templates/_helpers.tpl
+++ b/gateway/templates/_helpers.tpl
@@ -2,18 +2,6 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-*/}}
-{{- define "fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
 
 {{- define "imagePullSecret" }}
 {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" (required "A valid .Values.imageCredentials.registry entry required!" .Values.imageCredentials.registry) (printf "%s:%s" (required "A valid .Values.imageCredentials.username entry required!" .Values.imageCredentials.username) (required "A valid .Values.imageCredentials.password entry required!" .Values.imageCredentials.password) | b64enc) | b64enc }}
@@ -57,3 +45,7 @@ Inject extra environment populated by secrets, if populated
 {{- printf "%s-console-svc:443" .Release.Name -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "platform" }}
+{{- printf "%s" (required "A valid .Values.global.platform entry required" .Values.global.platform ) | replace "\n" "" }}
+{{- end }}

--- a/gateway/templates/gate-service.yaml
+++ b/gateway/templates/gate-service.yaml
@@ -9,6 +9,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    {{- if .Values.service.labels }}
+    {{ toYaml .Values.service.labels | indent 4 }}
+    {{- end }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/gateway/templates/rbac.yaml
+++ b/gateway/templates/rbac.yaml
@@ -1,29 +1,7 @@
-{{- if .Values.rbac.enabled -}}
-  {{- if not .Values.rbac.roleRef }}
----
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-    name: {{ .Release.Name }}-psp
-    labels:
-      app: {{ .Release.Name }}
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-      release: "{{ .Release.Name }}"
-      heritage: "{{ .Release.Service }}"
-spec:
-  privileged: {{ .Values.rbac.privileged }}
-  allowedCapabilities:
-  - '*'
-  fsGroup:
-    rule: RunAsAny
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  volumes:
-  - '*'
+{{- if .Values.rbac.create }}
+{{- if not .Values.global.platform -}}
+{{ template "platform" .}}
+{{- end }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -36,15 +14,15 @@ metadata:
     heritage: "{{ .Release.Service }}"
     rbac.example.com/aggregate-to-monitoring: "true"
 rules:
-- apiGroups: ["extensions"]
-  resourceNames: [{{ .Release.Name }}-psp]
-  resources: ["podsecuritypolicies"]
-  verbs: ["use"]
 - apiGroups: [""]
   resources: ["nodes", "services", "endpoints", "pods", "deployments", "namespaces","componentstatuses"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["*"]
+  verbs: ["get", "list", "watch"]
+{{- if eq .Values.platform "openshift" }}
+- apiGroups: [""]
+  resources: ["imagestreams", "imagestreams/layers"]
   verbs: ["get", "list", "watch"]
 {{- end }}
 ---
@@ -58,28 +36,28 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-subjects:
-  - kind: ServiceAccount
-    name: {{ .Release.Name }}-sa
-    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io
-  {{- if .Values.rbac.roleRef }}
-  name: {{ .Values.rbac.roleRef }}
+  {{- if .Values.clusterRole.roleRef }}
+  name: {{ .Values.clusterRole.roleRef }}
   {{- else }}
   name: {{ .Release.Name }}-cluster-role
   {{- end }}
-{{- if .Values.global.platform }}
-  {{- if eq .Values.global.platform "openshift" }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+
+{{- if eq .Values.global.platform "openshift" }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: cluster-reader
+  name: {{ .Release.Name }}-cluster-reader
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-sa
+    name: {{ .Values.serviceAccount.name }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -89,23 +67,10 @@ roleRef:
 allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: false
-allowHostPID: true
+allowHostPID: false
 allowHostPorts: false
-allowPrivilegeEscalation: false
+allowPrivilegeEscalation: true
 allowPrivilegedContainer: false
-allowedCapabilities:
-- SYS_ADMIN
-- NET_ADMIN
-- NET_RAW
-- SYS_PTRACE
-- KILL
-- MKNOD
-- SETGID
-- SETUID
-- SYS_MODULE
-- AUDIT_CONTROL
-- SYSLOG
-- SYS_CHROOT
 apiVersion: security.openshift.io/v1
 defaultAddCapabilities: null
 fsGroup:
@@ -118,18 +83,18 @@ metadata:
       but allows users to run with any non-root UID and access hostPath. The user must
       specify the UID or it must be specified on the by the manifest of the container runtime.
     release.openshift.io/create-only: "true"
-  name: aqua-scc
+  name: {{ .Release.Name }}-scc
 priority: null
 readOnlyRootFilesystem: false
 requiredDropCapabilities: null
 runAsUser:
-  type: RunAsAny
+  type: MustRunAsNonRoot
 seLinuxContext:
   type: MustRunAs
 supplementalGroups:
   type: RunAsAny
 users:
-- system:serviceaccount:aqua:aqua-sa
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.serviceAccount.name }}
 volumes:
 - configMap
 - downwardAPI
@@ -138,6 +103,24 @@ volumes:
 - projected
 - secret
 - hostPath
-  {{- end }}
 {{- end }}
+
+## TKG RBAC
+{{- if eq .Values.global.platform "tkg" }}
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rolebinding-default-privileged-sa-ns_default
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: psp:vmware-system-privileged
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: system:serviceaccounts
+{{- end -}}
+
 {{- end }}

--- a/gateway/templates/rbac.yaml
+++ b/gateway/templates/rbac.yaml
@@ -20,7 +20,7 @@ rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["*"]
   verbs: ["get", "list", "watch"]
-{{- if eq .Values.platform "openshift" }}
+{{- if eq .Values.global.platform "openshift" }}
 - apiGroups: [""]
   resources: ["imagestreams", "imagestreams/layers"]
   verbs: ["get", "list", "watch"]

--- a/gateway/values.yaml
+++ b/gateway/values.yaml
@@ -8,9 +8,11 @@ imageCredentials:
   password: ""
 
 rbac:
-  enabled: true
-  privileged: true
-  roleRef:
+  create: false # Enable to create RBAC for gateway chart
+
+clusterRole:
+  roleRef: ""
+
 console:
   publicIP:
   publicPort:
@@ -26,8 +28,9 @@ image:
   tag: "6.5"
   pullPolicy: Always
 service:
-  type: LoadBalancer     # you can enable gateway to internal by changing type to "clusterIP"
+  type: LoadBalancer     # Enable gateway to internal by changing type to "clusterIP"
   loadbalancerIP: "" # Specify loadBalancerIP address for aqua-web in AKS platform
+  labels: {}
   annotations: {}
   ports:
     - name: aqua-gate

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,9 +1,11 @@
-## 6.5.8 ( December 12, 2021 )
+## 6.5.9 ( December 14th, 2021 )
+* Update RBAC | default to non-privilege mode and remove capabilities in openshift SCC
+## 6.5.8 ( December 12th, 2021 )
 * Fix Openshift route configuration - [453](https://github.com/aquasecurity/aqua-helm/pull/453)
 * Add web service label support
-## 6.5.7 ( December 5, 2021 )
+## 6.5.7 ( December 5th, 2021 )
 * Move platform variable to global scope - [445](https://github.com/aquasecurity/aqua-helm/pull/445)
-## 6.5.6 ( December 2, 2021 )
+## 6.5.6 ( December 2nd, 2021 )
 * Add support for gateway headless service - [437](https://github.com/aquasecurity/aqua-helm/pull/437)
 ## 6.5.5 ( December 1st, 2021 )
 * Ingress definition updated for kubernetes versions up to 1.22 - [432](https://github.com/aquasecurity/aqua-helm/pull/432)

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 6.5.9 ( December 14th, 2021 )
-* Update RBAC | default to non-privilege mode and remove capabilities in openshift SCC
+* Update RBAC | default to non-privilege mode and remove capabilities in openshift SCC - [454](https://github.com/aquasecurity/aqua-helm/pull/454)
 ## 6.5.8 ( December 12th, 2021 )
 * Fix Openshift route configuration - [453](https://github.com/aquasecurity/aqua-helm/pull/453)
 * Add web service label support

--- a/server/Chart.lock
+++ b/server/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: gateway
   repository: file://../gateway/
-  version: 6.5.4
-digest: sha256:9e2c5aa24fd121c5a86349f7dbf8be18f9b87a05f84e38215dcf2658fde20b89
-generated: "2021-12-05T11:04:08.930299+02:00"
+  version: 6.5.5
+digest: sha256:75ea5873c1fda22987d1a910c476e74e4f48830d0b002617be9ffe8775454595
+generated: "2021-12-14T22:03:56.528412505+05:30"

--- a/server/Chart.yaml
+++ b/server/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 appVersion: "6.5"
 description: A Helm chart for the Aqua Console components
 name: server
-version: "6.5.8"
+version: "6.5.9"
 dependencies:
   - name: gateway
-    version: "6.5.4"
+    version: "6.5.5"
     repository: "file://../gateway/"
     condition: gateway.enabled
 icon: https://avatars3.githubusercontent.com/u/12783832?s=200&v=4

--- a/server/README.md
+++ b/server/README.md
@@ -281,9 +281,7 @@ Parameter | Description | Default| Mandatory
 `imageCredentials.password` | Your Docker registry (DockerHub, etc.) password | `unset`| `YES`
 `global.platform` | Orchestration platform name (Allowed values are aks, eks, gke, openshift, tkg, tkgi, k8s, rancher, gs, k3s) | `unset` | `YES`
 `openshift_route.create` | to create openshift routes for web and gateway | `false` | `NO`
-`rbac.enabled` | if to create rbac configuration for aqua | `true`| `YES`
-`rbac.privileged` | determines if any container in a pod can enable privileged mode. | `true`| `NO`
-`rbac.roleRef` | name of rbac role to set in not create by helm | `unset`| `NO`
+`clusterRole.roleRef` | cluster role reference name for cluster rolebinding | `unset` | `NO`
 `activeactive` | set for HA Active-Active cluster mode | `false`
 `clustermode` | set for HA Active-Passive cluster mode <br> To be deprecated, use Active-Active instead | `false`
 `admin.token`| Use this Aqua license token | `unset`| `NO`
@@ -338,7 +336,7 @@ Parameter | Description | Default| Mandatory
 `gateway.enabled` | Deploy gateway chart with server chart | `True`| `NO`
 `gateway.image.tag` | The image tag to use. | `6.5`| `NO`
 `gateway.image.pullPolicy` | The kubernetes image pull policy. | `IfNotPresent`| `NO`
-`gateway.service.type` | k8s service type | `ClusterIP`| `NO`
+`gateway.service.type` | k8s service type | `LoadBalancer`| `NO`
 `gateway.service.loadbalancerIP` | can specify loadBalancerIP address for aqua-web in AKS platform | `null` | `NO`
 `gateway.service.annotations` |	service annotations	| `{}` | `NO`
 `gateway.service.ports` | array of ports settings | `array`| `NO`

--- a/server/templates/rbac.yaml
+++ b/server/templates/rbac.yaml
@@ -19,7 +19,7 @@ rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["*"]
   verbs: ["get", "list", "watch"]
-{{- if eq .Values.platform "openshift" }}
+{{- if eq .Values.global.platform "openshift" }}
 - apiGroups: [""]
   resources: ["imagestreams", "imagestreams/layers"]
   verbs: ["get", "list", "watch"]

--- a/server/templates/rbac.yaml
+++ b/server/templates/rbac.yaml
@@ -1,29 +1,6 @@
-{{- if .Values.rbac.enabled -}}
-  {{- if not .Values.rbac.roleRef }}
----
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-    name: {{ .Release.Name }}-psp
-    labels:
-      app: {{ .Release.Name }}
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-      release: "{{ .Release.Name }}"
-      heritage: "{{ .Release.Service }}"
-spec:
-  privileged: {{ .Values.rbac.privileged }}
-  allowedCapabilities:
-  - '*'
-  fsGroup:
-    rule: RunAsAny
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  volumes:
-  - '*'
+{{- if not .Values.global.platform -}}
+{{ template "platform" .}}
+{{- end }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -36,15 +13,15 @@ metadata:
     heritage: "{{ .Release.Service }}"
     rbac.example.com/aggregate-to-monitoring: "true"
 rules:
-- apiGroups: ["extensions"]
-  resourceNames: [{{ .Release.Name }}-psp]
-  resources: ["podsecuritypolicies"]
-  verbs: ["use"]
 - apiGroups: [""]
   resources: ["nodes", "services", "endpoints", "pods", "deployments", "namespaces","componentstatuses"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["*"]
+  verbs: ["get", "list", "watch"]
+{{- if eq .Values.platform "openshift" }}
+- apiGroups: [""]
+  resources: ["imagestreams", "imagestreams/layers"]
   verbs: ["get", "list", "watch"]
 {{- end }}
 ---
@@ -58,27 +35,25 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  {{- if .Values.clusterRole.roleRef }}
+  name: {{ .Values.clusterRole.roleRef }}
+  {{- else }}
+  name: {{ .Release.Name }}-cluster-role
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Namespace }}-sa
     namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: ClusterRole
-  apiGroup: rbac.authorization.k8s.io
-  {{- if .Values.rbac.roleRef }}
-  name: {{ .Values.rbac.roleRef }}
-  {{- else }}
-  name: {{ .Release.Name }}-cluster-role
-  {{- end }}
 
-{{- if not .Values.global.platform -}}
-{{ template "platform" .}}
-{{- else if eq .Values.global.platform "openshift" }}
+{{- if eq .Values.global.platform "openshift" }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: cluster-reader
+  name: {{ .Release.Name }}-cluster-reader
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Namespace }}-sa
@@ -91,23 +66,10 @@ roleRef:
 allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: false
-allowHostPID: true
+allowHostPID: false
 allowHostPorts: false
-allowPrivilegeEscalation: false
+allowPrivilegeEscalation: true
 allowPrivilegedContainer: false
-allowedCapabilities:
-- SYS_ADMIN
-- NET_ADMIN
-- NET_RAW
-- SYS_PTRACE
-- KILL
-- MKNOD
-- SETGID
-- SETUID
-- SYS_MODULE
-- AUDIT_CONTROL
-- SYSLOG
-- SYS_CHROOT
 apiVersion: security.openshift.io/v1
 defaultAddCapabilities: null
 fsGroup:
@@ -120,18 +82,18 @@ metadata:
       but allows users to run with any non-root UID and access hostPath. The user must
       specify the UID or it must be specified on the by the manifest of the container runtime.
     release.openshift.io/create-only: "true"
-  name: aqua-scc
+  name: {{ .Release.Name }}-scc
 priority: null
 readOnlyRootFilesystem: false
 requiredDropCapabilities: null
 runAsUser:
-  type: RunAsAny
+  type: MustRunAsNonRoot
 seLinuxContext:
   type: MustRunAs
 supplementalGroups:
   type: RunAsAny
 users:
-- system:serviceaccount:aqua:aqua-sa
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Namespace }}-sa
 volumes:
 - configMap
 - downwardAPI
@@ -141,7 +103,10 @@ volumes:
 - secret
 - hostPath
 
-{{- else if eq .Values.global.platform "tkg" }}
+{{- end }}
+
+## TKG RBAC
+{{- if eq .Values.global.platform "tkg" }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -157,4 +122,3 @@ subjects:
   apiGroup: rbac.authorization.k8s.io
   name: system:serviceaccounts
 {{- end -}}
-{{- end }}

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -7,9 +7,7 @@ imageCredentials:
   username: ""
   password: ""
 
-rbac:
-  enabled: true
-  privileged: true
+clusterRole:
   roleRef: ""
 
 openshift_route:
@@ -155,8 +153,9 @@ gateway:
     tag: "6.5"
     pullPolicy: Always
   service:
-    type: ClusterIP     # you can enable gateway to external by changing type to "LoadBalancer"
+    type: LoadBalancer     # you can enable gateway to internal by changing type to "clusterIP"
     loadbalancerIP: "" # Specify loadBalancerIP address for aqua-web in AKS platform
+    labels: {}
     annotations: {}
     ports:
       - name: aqua-gate

--- a/tenant-manager/CHANGELOG.md
+++ b/tenant-manager/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 6.5.1 ( Dec 14th, 2021)
+* Update RBAC | default to non-privilege mode and remove capabilities in openshift SCC
 ## 6.5.0 ( Sep 11th, 2021)
 * First 6.5 changelog
 * adding 6.5 image tag

--- a/tenant-manager/CHANGELOG.md
+++ b/tenant-manager/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 6.5.1 ( Dec 14th, 2021)
-* Update RBAC | default to non-privilege mode and remove capabilities in openshift SCC
+* Update RBAC | default to non-privilege mode and remove capabilities in openshift SCC - [454](https://github.com/aquasecurity/aqua-helm/pull/454)
 ## 6.5.0 ( Sep 11th, 2021)
 * First 6.5 changelog
 * adding 6.5 image tag

--- a/tenant-manager/Chart.yaml
+++ b/tenant-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "6.5"
 description: A Helm chart for the Aqua Tenant Manager
 name: tenant-manager
-version: "6.5.0"
+version: "6.5.1"
 icon: https://avatars3.githubusercontent.com/u/12783832?s=200&v=4
 home: https://www.aquasec.com/
 maintainers:

--- a/tenant-manager/README.md
+++ b/tenant-manager/README.md
@@ -116,9 +116,7 @@ Parameter | Description | Default| Mandatory
 `imageCredentials.username` | Your Docker registry (Docker Hub, etc.) username | `aqua-registry-secret`| `YES` 
 `imageCredentials.password` | Your Docker registry (Docker Hub, etc.) password | `unset`| `YES` 
 `platform` | Orchestration platform (allowed values are aks, eks, gke, openshift, tkg, tkgi, k8s) | `unset` | `YES`
-`rbac.enabled` | Whether to create RBAC configuration for aqua | `true`| `YES` 
-`rbac.privileged` | WHether any container in a pod can enable privileged mode. | `true`| `NO` 
-`rbac.roleRef` | Name of RBAC role to set in not create by Helm | `unset`| `NO` 
+`clusterRole.roleRef` | cluster role reference name for cluster rolebinding | `unset` | `NO`
 `admin.token`| Use this Aqua license token | `unset`| `NO` 
 `admin.password` | Use this Aqua admin password | `unset`| `NO` 
 `db.external.enabled` | Avoid installing the packaged DB (Postgres container); use an external database instead | `false`| `YES` 

--- a/tenant-manager/templates/rbac.yaml
+++ b/tenant-manager/templates/rbac.yaml
@@ -1,29 +1,6 @@
-{{- if .Values.rbac.enabled -}}
-  {{- if not .Values.rbac.roleRef }}
----
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-    name: {{ .Release.Name }}-psp
-    labels:
-      app: {{ .Release.Name }}
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-      release: "{{ .Release.Name }}"
-      heritage: "{{ .Release.Service }}"
-spec:
-  privileged: {{ .Values.rbac.privileged }}
-  allowedCapabilities:
-  - '*'
-  fsGroup:
-    rule: RunAsAny
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  volumes:
-  - '*'
+{{- if not .Values.platform -}}
+{{ template "platform" .}}
+{{- end }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -36,15 +13,15 @@ metadata:
     heritage: "{{ .Release.Service }}"
     rbac.example.com/aggregate-to-monitoring: "true"
 rules:
-- apiGroups: ["extensions"]
-  resourceNames: [{{ .Release.Name }}-psp]
-  resources: ["podsecuritypolicies"]
-  verbs: ["use"]
 - apiGroups: [""]
   resources: ["nodes", "services", "endpoints", "pods", "deployments", "namespaces","componentstatuses"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["*"]
+  verbs: ["get", "list", "watch"]
+{{- if eq .Values.platform "openshift" }}
+- apiGroups: [""]
+  resources: ["imagestreams", "imagestreams/layers"]
   verbs: ["get", "list", "watch"]
 {{- end }}
 ---
@@ -58,27 +35,25 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  {{- if .Values.clusterRole.roleRef }}
+  name: {{ .Values.clusterRole.roleRef }}
+  {{- else }}
+  name: {{ .Release.Name }}-cluster-role
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-sa
     namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: ClusterRole
-  apiGroup: rbac.authorization.k8s.io
-  {{- if .Values.rbac.roleRef }}
-  name: {{ .Values.rbac.roleRef }}
-  {{- else }}
-  name: {{ .Release.Name }}-cluster-role
-  {{- end }}
 
-{{- if not .Values.platform -}}
-{{ template "platform" .}}
-{{- else if eq .Values.platform "openshift" }}
+{{- if eq .Values.platform "openshift" }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: cluster-reader
+  name: {{ .Release.Name }}-cluster-reader
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-sa
@@ -91,23 +66,10 @@ roleRef:
 allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: false
-allowHostPID: true
+allowHostPID: false
 allowHostPorts: false
-allowPrivilegeEscalation: false
+allowPrivilegeEscalation: true
 allowPrivilegedContainer: false
-allowedCapabilities:
-- SYS_ADMIN
-- NET_ADMIN
-- NET_RAW
-- SYS_PTRACE
-- KILL
-- MKNOD
-- SETGID
-- SETUID
-- SYS_MODULE
-- AUDIT_CONTROL
-- SYSLOG
-- SYS_CHROOT
 apiVersion: security.openshift.io/v1
 defaultAddCapabilities: null
 fsGroup:
@@ -120,18 +82,18 @@ metadata:
       but allows users to run with any non-root UID and access hostPath. The user must
       specify the UID or it must be specified on the by the manifest of the container runtime.
     release.openshift.io/create-only: "true"
-  name: aqua-scc
+  name: {{ .Release.Name }}-scc
 priority: null
 readOnlyRootFilesystem: false
 requiredDropCapabilities: null
 runAsUser:
-  type: RunAsAny
+  type: MustRunAsNonRoot
 seLinuxContext:
   type: MustRunAs
 supplementalGroups:
   type: RunAsAny
 users:
-- system:serviceaccount:aqua:aqua-sa
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-sa
 volumes:
 - configMap
 - downwardAPI
@@ -141,7 +103,10 @@ volumes:
 - secret
 - hostPath
 
-{{- else if eq .Values.platform "tkg" }}
+{{- end }}
+
+## TKG RBAC
+{{- if eq .Values.platform "tkg" }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -157,4 +122,3 @@ subjects:
   apiGroup: rbac.authorization.k8s.io
   name: system:serviceaccounts
 {{- end -}}
-{{- end }}

--- a/tenant-manager/values.yaml
+++ b/tenant-manager/values.yaml
@@ -7,9 +7,7 @@ imageCredentials:
   username: ""
   password: ""
 
-rbac:
-  enabled: true
-  privileged: false
+clusterRole:
   roleRef: ""
 
 #Please specify k8s platform acronym. Allowed values are aks, eks, gke, openshift, tkg, tkgi, k8s


### PR DESCRIPTION
* make server and gateway charts deploy in non-privileged mode
* add aqua logical & node in enforcer chart
* remove unnecessary capabilities to server and gateway charts
* remove deprecated api - policy/vbeta1