### PR TITLE
Add hostPath options for helm chart

### DIFF
--- a/enforcer/Chart.yaml
+++ b/enforcer/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "6.5"
 description: A Helm chart for the Aqua Enforcer
 name: enforcer

--- a/enforcer/README.md
+++ b/enforcer/README.md
@@ -145,10 +145,11 @@ Parameter | Description | Default| Mandatory
 `enforcerTokenSecretName` | enforcer token secret name if exists | `null`| `NO`
 `enforcerTokenSecretKey` | enforcer token secret key if exists | `null`| `NO`
 `logicalName` | Specify the Logical Name the Aqua Enforcer will register under. if not specify the name will be `spec.nodeName` | `unset`| `NO`
-`nodelName` | Specify the Node Name the Aqua Enforcer will register under. if not specify the name will be `spec.nodeName` | `unset`| `NO`
+`nodeName` | Specify the Node Name the Aqua Enforcer will register under. if not specify the name will be `spec.nodeName` | `unset`| `NO`
 `securityContext.privileged` | determines if any container in a pod can enable privileged mode. | `false`| `NO`
 `securityContext.capabilities` | Linux capabilities provide a finer grained breakdown of the privileges traditionally associated with the superuser. | `add {}`| `NO`
-`hostRunPath` |	for changing host run path for example for pks need to change to /var/vcap/sys/run/docker	| `unset`| `NO`
+`volumes.hostRun` | for changing host run path or type for example for pks need to change path to /var/vcap/sys/run/docker | `{}`| `NO`
+`volumes.aquasec` | for changing path or type of aquasec hostPath volume | `{}` | `NO`
 `gate.host` | gateway host | `aqua-gateway-svc`| `YES`
 `gate.port` | gateway port | `8443`| `YES`
 `image.repository` | the docker image name to use | `enforcer`| `YES`

--- a/enforcer/templates/enforcer-configmap.yaml
+++ b/enforcer/templates/enforcer-configmap.yaml
@@ -11,8 +11,8 @@ data:
   AQUA_SERVER: {{ .Values.gate.host | default "aqua-gateway-svc" }}:{{ .Values.gate.port | default "8443" }}
   {{- end }}
   AQUA_INSTALL_PATH: "/var/lib/aquasec"
-  {{- if .Values.hostRunPath }}
-  AQUA_HOST_RUN_PATH: {{ .Values.hostRunPath | quote }}
+  {{- if or .Values.hostRunPath .Values.volumes.hostRun }}
+  AQUA_HOST_RUN_PATH: {{ coalesce (dig "hostRun" "path" "" .Values.volumes) .Values.hostRunPath | quote }}
   {{- end }}
   {{- if .Values.TLS.enabled }}
   AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/key.pem"

--- a/enforcer/templates/enforcer-daemonset.yaml
+++ b/enforcer/templates/enforcer-daemonset.yaml
@@ -123,16 +123,11 @@ spec:
       schedulerName: {{ .Values.schedulerName }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       volumes:
-      {{- if .Values.hostRunPath }}
+      {{ $volumes := .Values.volumes }}
       - name: var-run
         hostPath:
-          path: {{ .Values.hostRunPath }}
-      {{- else }}
-      - name: var-run
-        hostPath:
-          path: /var/run
-          type: ""
-      {{- end }}
+          path: {{ coalesce (dig "hostRun" "path" "" $volumes) .Values.hostRunPath "/var/lib" | quote }} 
+          type: {{ dig "hostRun" "type" "" $volumes | quote }}
       - name: dev
         hostPath:
           path: /dev
@@ -151,19 +146,21 @@ spec:
           type: ""
       - name: aquasec
         hostPath:
-          path: /var/lib/aquasec
-          type: ""
+          path: {{ coalesce (dig "aquasec" "path" "" $volumes) "/var/lib/aquasec" | quote }}
+          type: {{ dig "aquasec" "type" "" $volumes | quote }}
       - name: aquasec-tmp
         hostPath:
-          path: /var/lib/aquasec/tmp
+          path: {{ print (coalesce (dig "aquasec" "path" "" $volumes) "/var/lib/aquasec") "/tmp" | quote }}
           type: ""
       - name: aquasec-audit
         hostPath:
-          path: /var/lib/aquasec/audit
+          path: {{ print (coalesce (dig "aquasec" "path" "" $volumes) "/var/lib/aquasec") "/audit" | quote }}
+          type: ""
       - name: aquasec-data
         hostPath:
-          path: /var/lib/aquasec/data
+          path: {{ print (coalesce (dig "aquasec" "path" "" $volumes) "/var/lib/aquasec") "/data" | quote }}
           type: ""
+
       {{- if .Values.TLS.enabled }}
       - name: certs
         secret:

--- a/enforcer/values.yaml
+++ b/enforcer/values.yaml
@@ -53,7 +53,18 @@ securityContext:
       - SYS_RESOURCE
       - IPC_LOCK
 
-hostRunPath: # pks - /var/vcap/sys/run/docker
+# use the below volumes to configure path and type for hostPath volumes
+# volumes:
+#   hostRun:
+#     path: /var/vcap/sys/run/docker
+#     type: ""
+#   aquasec:
+#     path: /var/lib/docker/aquasec
+#     type: DirectoryOrCreate
+volumes: {}
+
+# deprecated, use "volumes.hostRun" instead.
+# hostRunPath:
 
 multiple_gateway: # enable this to connect enforcer with multiple gateways
   enabled: false
@@ -65,7 +76,6 @@ gate:
 multi_gates:  # use the below hosts to add multiple gateways as required to enforcer. Format is <hostname>:<port_number>
 - aqua-gateway1-svc:8443 #example gateway 1
 - aqua-gateway2-svc:8443 #example gateway 2
-
 
 image:
   repository: enforcer


### PR DESCRIPTION
This PR tries to add the possibility of using a different path for the hostPath volumes aquasec uses as pointed in issue #503  
https://github.com/aquasecurity/aqua-helm/issues/503

For consistency, it moves the "hostRunPath" value to a new place while being backward compatible.

Version of helm is updated and a minor typo is corrected.