### PR TITLE
Scanner | 6.5 | Improvement | Specify which registries this scanner is allowed to scan

### DIFF
--- a/scanner/templates/scanner-deployment.yaml
+++ b/scanner/templates/scanner-deployment.yaml
@@ -65,6 +65,10 @@ spec:
         {{- else }}
         - --no-verify
         {{- end }}
+        {{- if .Values.registries }}
+        - --registries
+        - {{ join "," .Values.registries }}
+        {{- end }}
         envFrom:
         - configMapRef:
             name: {{ .Release.Name }}-scanner-config        

--- a/scanner/values.yaml
+++ b/scanner/values.yaml
@@ -114,3 +114,10 @@ extraSecretEnvironmentVars: []
   # - envName: ENV_NAME
   #   secretName: name
   #   secretKey: key
+
+# A list of speficic registries this scanner will be used for
+# If none are passed, the scanner will be used for all registries
+registries: []
+# registries:
+# - registry1
+# - registry2


### PR DESCRIPTION
Adding the following entry in the values file:

```
registries: []
# registries:
# - registry1
# - registry2
```

Which will allow users to specify a list of dedicated registries for this scanner