### PR TITLE
Enforcer | 6.5 | Improvement: Adding Proxy values for Enforcer

### DIFF
--- a/enforcer/README.md
+++ b/enforcer/README.md
@@ -155,8 +155,9 @@ Parameter | Description | Default| Mandatory
 `extraEnvironmentVars` | is a list of extra environment variables to set in the enforcer daemonset. | `{}`| `NO`
 `extraSecretEnvironmentVars` | is a list of extra environment variables to set in the scanner daemonset, these variables take value from existing Secret objects. | `[]`| `NO`
 `proxy.enabled` | If require secure a proxy for the communication between Enforcers and Gateway | `false` | `NO`
-`proxy.enabled.http` | HTTP proxy value, used only if proxy.enabled = true | `` | `NO`
-`proxy.enabled.https` | HTTPS proxy value, used only if proxy.enabled = true | `false` | `NO`
+`proxy.http` | HTTP proxy value, used only if proxy.enabled = true | `` | `NO`
+`proxy.https` | HTTPS proxy value, used only if proxy.enabled = true | `` | `NO`
+`proxy.no_proxy` | Exclusions for proxy, used only if proxy.enabled = true | `` | `NO`
 
 
 > Note: that `imageCredentials.create` is false and if you need to create image pull secret please update to true, set the username and password for the registry and `serviceAccount.create` is false and if you're environment is new or not having aqua-sa serviceaccount please update it to true.

--- a/enforcer/README.md
+++ b/enforcer/README.md
@@ -154,6 +154,9 @@ Parameter | Description | Default| Mandatory
 `TLS.aqua_verify_enforcer` | change it to "1" or "0" for enabling/disabling mTLS between enforcer and ay/envoy | `0`  |  `YES` <br /> `if TLS.enabled is set to true`
 `extraEnvironmentVars` | is a list of extra environment variables to set in the enforcer daemonset. | `{}`| `NO`
 `extraSecretEnvironmentVars` | is a list of extra environment variables to set in the scanner daemonset, these variables take value from existing Secret objects. | `[]`| `NO`
+`proxy.enabled` | If require secure a proxy for the communication between Enforcers and Gateway | `false` | `NO`
+`proxy.enabled.http` | HTTP proxy value, used only if proxy.enabled = true | `` | `NO`
+`proxy.enabled.https` | HTTPS proxy value, used only if proxy.enabled = true | `false` | `NO`
 
 
 > Note: that `imageCredentials.create` is false and if you need to create image pull secret please update to true, set the username and password for the registry and `serviceAccount.create` is false and if you're environment is new or not having aqua-sa serviceaccount please update it to true.

--- a/enforcer/templates/enforcer-daemonset.yaml
+++ b/enforcer/templates/enforcer-daemonset.yaml
@@ -85,6 +85,12 @@ spec:
         - name: HTTPS_PROXY
           value: {{ .Values.proxy.https }}
         {{- end }}
+        {{- if .Values.proxy.no_proxy }}
+        - name: no_proxy
+          value: {{ .Values.proxy.no_proxy }}
+        - name: NO_PROXY
+          value: {{ .Values.proxy.no_proxy }}
+        {{- end }}
         {{- end }}
         {{- include "enforcer.extraEnvironmentVars" .Values | nindent 8 -}}
         {{- include "enforcer.extraSecretEnvironmentVars" .Values | nindent 8 -}}

--- a/enforcer/templates/enforcer-daemonset.yaml
+++ b/enforcer/templates/enforcer-daemonset.yaml
@@ -72,8 +72,22 @@ spec:
               name: {{ .Release.Name }}-token
               key: token
         {{- end }}
-        {{- include "enforcer.extraEnvironmentVars" .Values | nindent 8 }}
-        {{- include "enforcer.extraSecretEnvironmentVars" .Values | nindent 8 }}
+        {{- if .Values.proxy.enabled }}
+        {{- if .Values.proxy.http }}
+        - name: http_proxy
+          value: {{ .Values.proxy.http }}
+        - name: HTTP_PROXY
+          value: {{ .Values.proxy.http }}
+        {{- end -}}
+        {{- if .Values.proxy.https }}
+        - name: https_proxy
+          value: {{ .Values.proxy.https }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.proxy.https }}
+        {{- end }}
+        {{- end }}
+        {{- include "enforcer.extraEnvironmentVars" .Values | nindent 8 -}}
+        {{- include "enforcer.extraSecretEnvironmentVars" .Values | nindent 8 -}}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/enforcer/values.yaml
+++ b/enforcer/values.yaml
@@ -133,3 +133,4 @@ proxy:
   enabled: false
   http: ""
   https: ""
+  no_proxy: ""

--- a/enforcer/values.yaml
+++ b/enforcer/values.yaml
@@ -127,3 +127,9 @@ extraSecretEnvironmentVars: []
   # - envName: ENV_NAME
   #   secretName: name
   #   secretKey: key
+
+# Set environment variables for Proxy connectivy: Enforcer -> Proxy -> Gateway
+proxy:
+  enabled: false
+  http: ""
+  https: ""


### PR DESCRIPTION
Enforcer requires lower case env vars to set proxy urls.
Currently the ExtraEnvironmentVars set by the chart get converted in upper case and the Enforcer seems to ignore those settings unless provided in lower case.