### PR TITLE
Fix | 6.5 | KE | Health checks for old kube enforcers fails to render

### DIFF
--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -143,12 +143,14 @@ livenessProbe:
 
 ## Please use the below probes for KubeEnforcer version < 6.5.22052 or version != latest
 ## livenessProbe:
+##   httpGet:
 ##   tcpSocket:
 ##     port: 8080
 ##   initialDelaySeconds: 60
 ##   periodSeconds: 30
-## 
+##
 ## readinessProbe:
+##   httpGet:
 ##   tcpSocket:
 ##     port: 8080
 ##   initialDelaySeconds: 60


### PR DESCRIPTION
Using the old Kube Enforcer liveness and readiness probes (which don't include `/healthz`) breaks the chart deployment due to this error:

```
Error: UPGRADE FAILED: cannot patch "aqua-kube-enforcer" with kind Deployment: Deployment.apps "aqua-kube-enforcer" is invalid: [spec.template.spec.containers[0].livenessProbe.tcpSocket: Forbidden: may not specify more than 1 handler type, spec.template.spec.containers[0].readinessProbe.tcpSocket: Forbidden: may not specify more than 1 handler type]
```

Indeed the rendered manifest looks like this:
```
livenessProbe:
  httpGet:
    path: /healthz
    port: 8080
  initialDelaySeconds: 60
  periodSeconds: 30
  tcpSocket:
    port: 8080
readinessProbe:
  httpGet:
    path: /readyz
    port: 8080
  initialDelaySeconds: 60
  periodSeconds: 30
  tcpSocket:
    port: 8080
```

As shown in the code above, Helm keeps appending the `httpGet` prob, on top of the `tcpSocket` one, causing the issue.

In the fix I set an empty `httpGet` entry to prevent Helm from automatically rendering that bit.