### PR TITLE
Separate size of database and audit-database in values

### DIFF
--- a/server/templates/db-deployment.yaml
+++ b/server/templates/db-deployment.yaml
@@ -61,7 +61,7 @@ spec:
         image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.global.db.image.repository }}:{{ .Values.global.db.image.tag }}"
         command: [ "sh", "-c", "[ -f $PGDATA/server.key ] && chmod 600 $PGDATA/server.key || echo 'OK' " ]
         volumeMounts:
-        {{- if .Values.global.db.persistence.enabled }}
+        {{- if .Values.global.db.persistence.database.enabled }}
         - mountPath: /var/lib/postgresql/data
           name: postgres-database
         {{- end }}
@@ -97,7 +97,7 @@ spec:
         {{- include "server.extraEnvironmentVars" .Values.global.db | nindent 8 }}
         {{- include "server.extraSecretEnvironmentVars" .Values.global.db | nindent 8 }}
         volumeMounts:
-        {{- if .Values.global.db.persistence.enabled }}
+        {{- if .Values.global.db.persistence.database.enabled }}
         - mountPath: /var/lib/postgresql/data
           name: postgres-database
         {{- end }}
@@ -127,7 +127,7 @@ spec:
 {{ toYaml .Values.global.db.tolerations | indent 6 }}
       {{- end }}
       volumes:
-      {{- if .Values.global.db.persistence.enabled }}
+      {{- if .Values.global.db.persistence.database.enabled }}
       - name: postgres-database
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-database-pvc
@@ -191,7 +191,7 @@ spec:
         image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.global.db.image.repository }}:{{ .Values.global.db.image.tag }}"
         command: [ "sh", "-c", "[ -f $PGDATA/server.key ] && chmod 600 $PGDATA/server.key || echo 'OK' " ]
         volumeMounts:
-        {{- if .Values.global.db.persistence.enabled }}
+        {{- if .Values.global.db.persistence.audit_database.enabled }}
         - mountPath: /var/lib/postgresql/data
           name: postgres-audit-database
         {{- end }}
@@ -227,7 +227,7 @@ spec:
         {{- include "server.extraEnvironmentVars" .Values.global.db | nindent 8 }}
         {{- include "server.extraSecretEnvironmentVars" .Values.global.db | nindent 8 }}
         volumeMounts:
-        {{- if .Values.global.db.persistence.enabled }}
+        {{- if .Values.global.db.persistence.audit_database.enabled }}
         - mountPath: /var/lib/postgresql/data
           name: postgres-audit-database
         {{- end }}
@@ -257,7 +257,7 @@ spec:
 {{ toYaml .Values.global.db.tolerations | indent 6 }}
       {{- end }}
       volumes:
-      {{- if .Values.global.db.persistence.enabled }}
+      {{- if .Values.global.db.persistence.audit_database.enabled }}
       - name: postgres-audit-database
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-audit-database-pvc

--- a/server/templates/db-pvc.yaml
+++ b/server/templates/db-pvc.yaml
@@ -1,8 +1,29 @@
-{{- if and (not .Values.global.db.external.enabled) (.Values.global.db.persistence.enabled) }}
+{{- if and (not .Values.global.db.external.enabled) (.Values.global.db.persistence.database.enabled) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-database-pvc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-db
+    aqua.component: database
+{{ include "aqua.labels" . | indent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.global.db.persistence.database.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.global.db.persistence.database.size | quote }}
+{{- if .Values.global.db.persistence.database.storageClass }}
+  storageClassName: "{{ .Values.global.db.persistence.database.storageClass }}"
+{{- end }}
+{{- end }}
+---
+{{- if and (not .Values.global.db.external.enabled) (.Values.global.db.persistence.audit_database.enabled) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-audit-database-pvc
   namespace: {{ .Release.Namespace }}
   labels:
     app: aqua-audit-db
@@ -10,30 +31,11 @@ metadata:
 {{ include "aqua.labels" . | indent 4 }}
 spec:
   accessModes:
-    - {{ .Values.global.db.persistence.accessMode | quote }}
+    - {{ .Values.global.db.persistence.audit_database.accessMode | quote }}
   resources:
     requests:
-      storage: {{ .Values.global.db.persistence.size | quote }}
-{{- if .Values.global.db.persistence.storageClass }}
-  storageClassName: "{{ .Values.global.db.persistence.storageClass }}"
-{{- end }}
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: {{ .Release.Name }}-audit-database-pvc
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: {{ .Release.Name }}
-    aqua.component: database
-{{ include "aqua.labels" . | indent 4 }}
-spec:
-  accessModes:
-    - {{ .Values.global.db.persistence.accessMode | quote }}
-  resources:
-    requests:
-      storage: {{ .Values.global.db.persistence.size | quote }}
-{{- if .Values.global.db.persistence.storageClass }}
-  storageClassName: "{{ .Values.global.db.persistence.storageClass }}"
+      storage: {{ .Values.global.db.persistence.audit_database.size | quote }}
+{{- if .Values.global.db.persistence.audit_database.storageClass }}
+  storageClassName: "{{ .Values.global.db.persistence.audit_database.storageClass }}"
 {{- end }}
 {{- end }}

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -101,10 +101,16 @@ global:
     service:
       type: ClusterIP
     persistence:
-      enabled: true
-      storageClass:
-      size: 30Gi
-      accessMode: ReadWriteOnce
+      database:
+        enabled: true
+        storageClass:
+        size: 5Gi
+        accessMode: ReadWriteOnce
+      audit_database:
+        enabled: true
+        storageClass:
+        size: 30Gi
+        accessMode: ReadWriteOnce
     livenessProbe:
       exec:
         command:


### PR DESCRIPTION
Separate size of database and audit database in values.yaml file.
We think that we do not need the same size of operational database and audit database. We should be able to choose different storage sizes for operational and audit databases.
Based on our experience, it seems that by default these values should be different:
- 5 GB for the operational database (although in our case the operational database uses about 600 MB, so perhaps 1 or 2 GB would be even a better default choice?)
- 30 GB (current value) for audit database