### PR TITLE
Removing aqua-registry imagePull secret from Kube-Enforcer values.yml

### DIFF
--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -31,7 +31,7 @@ global:
     # If imageCredentials.create=create and imageCredentials.name defined
     # then will be created a secret with name provided name
     create: false
-    name: "aqua-registry"
+    name:
     repositoryUriPrefix: "registry.aquasec.com" # for dockerhub - "docker.io"
     registry: "registry.aquasec.com" #REQUIRED only if create is true, for dockerhub - "index.docker.io/v1/"
     username: ""


### PR DESCRIPTION
The `imageCredentials.name`  in this repo by default  is `aqua-registry-secret`. If this value is not defined(empty) in the `values.yaml` file the `templates/helpers.tpl` will use by default `aqua-registry-secret.`


As example, Aqua Enforcer - https://github.com/aquasecurity/aqua-helm/blob/2022.4/enforcer/values.yaml#L24 

Therefore, for consistency, we should leave empty `imageCredentials.name` in Kube-enforcer values.yaml.