### PR TITLE
Remove extra if condition not related to image pull secret creation

### DIFF
--- a/enforcer/templates/image-pull-secret.yaml
+++ b/enforcer/templates/image-pull-secret.yaml
@@ -1,4 +1,3 @@
-{{- if not .Values.global.enforcer.enabled -}}
 {{- if .Values.global.imageCredentials.create -}}
 ---
 apiVersion: v1
@@ -13,5 +12,4 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "imagePullSecret" . }}
-{{- end -}}
 {{- end -}}


### PR DESCRIPTION
Removing an extra `if condition` during the creation of the enforcer's image pull secret.  

As far as we can tell, all of the other image pull secret manifests only check for the `imageCredentials.create` value.  The resulting behavior of this file is that if you have `global.enforcer.enabled=true`, an image pull secret is not created for the enforcer.  This behavior seems unintended.