### PR TITLE
Add PodDisruptionBudget to kube-enforcer deployment

### DIFF
--- a/kube-enforcer/templates/kube-enforcer-poddisruptionbudget.yaml
+++ b/kube-enforcer/templates/kube-enforcer-poddisruptionbudget.yaml
@@ -1,0 +1,20 @@
+{{- if gt (.Values.ke_ReplicaCount | default "1" | int) 1 }}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    role: {{ .Release.Name }}
+    app: {{ include "kube-enforcer.fullname" . }}
+    aqua.component: kubeenforcer
+{{ include "aqua.labels" . | indent 4 }}
+  name: {{ include "kube-enforcer.fullname" . }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ include "kube-enforcer.fullname" . }}
+{{- end }}

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -172,6 +172,9 @@ podAnnotations: {}
 podLabels: {}
 affinity: {}
 
+podDisruptionBudget:
+  minAvailable: 1
+
 TLS:
   # enable to true for secure communication
   enabled: false


### PR DESCRIPTION
This PR introduces a Pod Disruption Budget https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ for the kube-enforcer deployment.

As this service is the target of the validating webhook it would be best to ensure it's availability during disruptions, The PDB is enabled by default for any deployment with `> 1` replicas.

This should be used in combination with an anti-affinity rule to ensure a spread of pods across nodes which would be nice to default but I did not include this with this PR as I can set this in our environment for now using the charts values.



