### PR TITLE
Exclude Nodes From Kube-Bench based on labels

### DIFF
--- a/kube-enforcer/templates/kube-enforcer-configmap.yaml
+++ b/kube-enforcer/templates/kube-enforcer-configmap.yaml
@@ -15,6 +15,7 @@ data:
   AQUA_CACHE_EXPIRATION_PERIOD: {{ .Values.aqua_cache_expiration_period | default "60" | quote }}
   AQUA_LOGICAL_NAME: {{ .Values.logicalName | quote }}
   CLUSTER_NAME: {{ .Values.clusterName | quote }}
+  NODE_LABELS_TO_SKIP_KUBE_BENCH: {{ .Values.skipNodes | quote }}
   {{- if .Values.me_ke_custom_registry.enable }}
   AQUA_KB_IMAGE_NAME: "{{ .Values.me_ke_custom_registry.registry }}/{{ .Values.kubebenchImage.repository }}:{{ .Values.kubebenchImage.tag }}"
   AQUA_ME_IMAGE_NAME: "{{ .Values.me_ke_custom_registry.registry }}/{{ .Values.microEnforcerImage.repository }}:{{ .Values.microEnforcerImage.tag }}"

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -91,6 +91,9 @@ clusterName: "Default-cluster-name"
 logicalName: ""
 logLevel: ""
 
+#Comma-separated node-labels for nodes on which Kube-Bench is to be skipped. key1=val1,key2=val2,...
+skipNodes: ""
+
 # Set create to false if you want to use an existing secret for the kube-enforcer certs
 # If certsSecret.create and certsSecret.name defined then need provide certsSecret.serverCertificate and
 # certsSecret.serverKey and webhooks.caBundle encrypted with base64 and secret for TLS connectivity with kube-api will be created


### PR DESCRIPTION
In this change we are adding a new configuration setting to provide node labels as a
comma-separated list of key=val pairs in the KE configmap. Kube-Bench will not
be run on nodes with these labels. List is empty by default