### PR TITLE
Fix | 2022.4 | Server/Gateway: pre-existing service account name is ignored by Gateway chart in custom namespaces

### DIFF
--- a/gateway/templates/_helpers.tpl
+++ b/gateway/templates/_helpers.tpl
@@ -68,7 +68,7 @@ If Values.serviceAccount.create defined as false
 And will be used serviceAccount created by parrent chart
 */}}
 {{- define "gateway.serviceAccount" -}}
-{{- if and .Values.serviceAccount.create .Values.serviceAccount.name -}}
+{{- if .Values.serviceAccount.name -}}
 {{- printf "%s" .Values.serviceAccount.name -}}
 {{- else -}}
 {{- if not .Values.serviceAccount.create -}}

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -200,6 +200,7 @@ gateway:
     publicPort:
   serviceAccount:
     create: false
+    name: ""
   replicaCount: 1
   logLevel:
   image:


### PR DESCRIPTION
This change fixes an issue that causes the wrong service account to be assigned to the gateway under these circumstances:
- server chart is used to deploy server and gateway
- charts are installed into custom namespace
- serviceAccount.create=false and gateway.serviceAccount.create=false

The specific issue with the current chart is that the gatway will not receive the service account name and in the deployment manifest will assign "namespace-sa" service account to the gateway. This results in a gateway pod not starting