### PR TITLE
SAAS-8690 [codesec-agent] remove client_url from validator

### DIFF
--- a/codesec-agent/CHANGELOG.md
+++ b/codesec-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+_1.2.1_
+* Remove "client_url" from env vars validator.
+
 _1.2.0_
 * Add "extraEnv" setting to scanner and connector containers.
 

--- a/codesec-agent/Chart.yaml
+++ b/codesec-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: codesec-agent
 description: A Helm chart for Aqua supply chain security
-version: "1.2.0"
+version: "1.2.1"
 icon: https://avatars3.githubusercontent.com/u/12783832?s=200&v=4
 home: https://www.aquasec.com
 maintainers:

--- a/codesec-agent/templates/validator.yaml
+++ b/codesec-agent/templates/validator.yaml
@@ -28,6 +28,3 @@
 {{- if empty .Values.integration.source }}
 {{ fail "Error - missing .Values.integration.source" }}
 {{- end }}
-{{- if empty .Values.connect.client_url }}
-{{ fail "Error - missing .Values.connect.client_url" }}
-{{- end }}


### PR DESCRIPTION
Remove the client_url from the validator since it is not mandatory 
https://scalock.atlassian.net/browse/SAAS-8690