### PR TITLE
Fix | 2022.4 | Server, Enforcer | PodSecurityPolicies

### DIFF
--- a/enforcer/README.md
+++ b/enforcer/README.md
@@ -137,51 +137,53 @@ For more details please visit [Link](https://docs.aquasec.com/docs/kubernetes#se
 
 ### Enforcer
 
-Parameter | Description  | Default  | Mandatory
---------- |--------------|----------| ---------
-`imageCredentials.create` | Set if to create new pull image secret  | `false`  | `YES - New cluster`
-`imageCredentials.name` | Your Docker pull image secret name | `aqua-registry-secret` | `YES - New cluster`
-`imageCredentials.repositoryUriPrefix` | repository uri prefix for dockerhub set `docker.io` | `registry.aquasec.com` | `YES - New cluster`
-`imageCredentials.registry` | set the registry url for dockerhub set `index.docker.io/v1/` | `registry.aquasec.com` | `YES - New cluster`
-`imageCredentials.username` | Your Docker registry (DockerHub, etc.) username  | `aqua-registry-secret` | `YES - New cluster`
-`imageCredentials.password` | Your Docker registry (DockerHub, etc.) password  | `unset` | `YES - New cluster`
-`serviceAccount.create` | enable to create serviceaccount | `false`    | `YES - New cluster`
-`serviceAccount.name` | service acccount name | `aqua-sa`  | `NO`
-`clusterRole.roleRef` | cluster role reference name for cluster rolebinding| `unset`    | `NO`
-`platform` | Orchestration platform name (Allowed values are aks, eks, gke, openshift, tkg, tkgi, k8s, rancher, gs, k3s)| `unset`    | `YES`
-`vaultSecret.enable` | Enable to true once you have secrets in vault and annotations are enabled to load enforcer token from hashicorp vault | `false` | `No` |
-`vaultSecret.vaultFilepath` |  Change the path to "/vault/secrets/<filename>" as per the setup | `""` | `No` |
-`enforcerToken` | enforcer token value | `enforcer-token`  | `YES` if `enforcerTokenSecretName` is set to null
-`expressMode` | Install enforcer in EXPRESS MODE or not | `false` | `YES`
-`enforcerTokenSecretName` | enforcer token secret name if exists | `null`     | `NO`
-`enforcerTokenSecretKey` | enforcer token secret key if exists | `null`     | `NO`
-`logicalName` | Specify the Logical Name the Aqua Enforcer will register under. if not specify the name will be `spec.nodeName`  | `unset`    | `NO`
-`nodelName` | Specify the Node Name the Aqua Enforcer will register under. if not specify the name will be `spec.nodeName` | `unset`    | `NO`
-`securityContext.privileged` | determines if any container in a pod can enable privileged mode. | `false`    | `NO`
-`securityContext.capabilities` | Linux capabilities provide a finer grained breakdown of the privileges traditionally associated with the superuser.    | `add {}`   | `NO`
-`global.gateway.address` | Gateway host address | `aqua-gateway-svc`     | `YES`
-`global.gateway.port` | Gateway host port | `8443` | `YES`
-`priorityClass.create` | If true priority class will be created  | `False`    | `NO`
-`priorityClass.name` | Define the name of priority class or default value will be used        | ``         | `NO`
-`priorityClass.preemptionPolicy` | Preemption policy for priority class    | `PreemptLowerPriority` | `NO`
-`priorityClass.value` | `The integer value of the priority`     | `1000000`  | `NO`
-`image.repository` | the docker image name to use| `enforcer` | `YES`
-`image.tag` | The image tag to use.       | `2022.4`   | `YES`
-`image.pullPolicy` | The kubernetes image pull policy.       | `Always`   | `NO`
-`healthMonitor.enabled` | Enabling health monitoring for enforcer liveness and readiness         | `true`     | `YES`
-`resources` | 	Resource requests and limits | `{}`  | `NO`
-`nodeSelector` | 	Kubernetes node selector	  | `{}`       | `NO`
-`tolerations` | 	Kubernetes node tolerations	 | `[]`       | `NO`
-`podAnnotations` | Kubernetes pod annotations  | `{}`       | `NO`
-`affinity` | 	Kubernetes node affinity   | `{}`       | `NO`
-`TLS.enabled` | If require secure channel communication | `false`    | `NO`
-`TLS.secretName` | certificates secret name    | `nil`      | `YES` <br /> `if TLS.enabled is set to true`
-`TLS.publicKey_fileName` | filename of the public key eg: aqua_enforcer.crt | `nil`      |  `YES` <br /> `if TLS.enabled is set to true`
-`TLS.privateKey_fileName`   | filename of the private key eg: aqua_enforcer.key| `nil`      |  `YES` <br /> `if TLS.enabled is set to true`
-`TLS.rootCA_fileName` | filename of the rootCA, if using self-signed certificates eg: rootCA.crt | `nil`      |  `NO` <br /> `if TLS.enabled is set to true and using self-signed certificates for TLS/mTLS`
-`TLS.aqua_verify_enforcer` | change it to "1" or "0" for enabling/disabling mTLS between enforcer and ay/envoy  | `0`        |  `YES` <br /> `if TLS.enabled is set to true`
-`extraEnvironmentVars` | is a list of extra environment variables to set in the enforcer daemonset.         | `{}`       | `NO`
-`extraSecretEnvironmentVars` | is a list of extra environment variables to set in the scanner daemonset, these variables take value from existing Secret objects. | `[]`       | `NO`
+Parameter | Description                                                                                                                        | Default                                    | Mandatory
+--------- |------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------| ---------
+`imageCredentials.create` | Set if to create new pull image secret                                                                                             | `false`                                    | `YES - New cluster`
+`imageCredentials.name` | Your Docker pull image secret name                                                                                                 | `aqua-registry-secret`                     | `YES - New cluster`
+`imageCredentials.repositoryUriPrefix` | repository uri prefix for dockerhub set `docker.io`                                                                                | `registry.aquasec.com`                     | `YES - New cluster`
+`imageCredentials.registry` | set the registry url for dockerhub set `index.docker.io/v1/`                                                                       | `registry.aquasec.com`                     | `YES - New cluster`
+`imageCredentials.username` | Your Docker registry (DockerHub, etc.) username                                                                                    | `aqua-registry-secret`                     | `YES - New cluster`
+`imageCredentials.password` | Your Docker registry (DockerHub, etc.) password                                                                                    | `unset`                                    | `YES - New cluster`
+`serviceAccount.create` | enable to create serviceaccount                                                                                                    | `false`                                    | `YES - New cluster`
+`serviceAccount.name` | service acccount name                                                                                                              | `aqua-sa`                                  | `NO`
+`clusterRole.roleRef` | cluster role reference name for cluster rolebinding                                                                                | `unset`                                    | `NO`
+`platform` | Orchestration platform name (Allowed values are aks, eks, gke, openshift, tkg, tkgi, k8s, rancher, gs, k3s)                        | `unset`                                    | `YES`
+`vaultSecret.enable` | Enable to true once you have secrets in vault and annotations are enabled to load enforcer token from hashicorp vault              | `false`                                    | `No` |
+`vaultSecret.vaultFilepath` | Change the path to "/vault/secrets/<filename>" as per the setup                                                                    | `""`                                       | `No` |
+`enforcerToken` | enforcer token value                                                                                                               | `enforcer-token`                           | `YES` if `enforcerTokenSecretName` is set to null
+`expressMode` | Install enforcer in EXPRESS MODE or not                                                                                            | `false`                                    | `YES`
+`enforcerTokenSecretName` | enforcer token secret name if exists                                                                                               | `null`                                     | `NO`
+`enforcerTokenSecretKey` | enforcer token secret key if exists                                                                                                | `null`                                     | `NO`
+`logicalName` | Specify the Logical Name the Aqua Enforcer will register under. if not specify the name will be `spec.nodeName`                    | `unset`                                    | `NO`
+`nodelName` | Specify the Node Name the Aqua Enforcer will register under. if not specify the name will be `spec.nodeName`                       | `unset`                                    | `NO`
+`securityContext.privileged` | determines if any container in a pod can enable privileged mode.                                                                   | `false`                                    | `NO`
+`securityContext.capabilities` | Linux capabilities provide a finer grained breakdown of the privileges traditionally associated with the superuser.                | `add {}`                                   | `NO`
+`podSecurityPolicy.create` | Enable Pod Security Policies with the required enforcer capabilities                                                               | `false`                                    | `NO`
+`podSecurityPolicy.privileged` | Enable privileged permissions to the Enforcer                                                                                      | `true` if podSecurityPolicy.create is `true` | `NO`
+`global.gateway.address` | Gateway host address                                                                                                               | `aqua-gateway-svc`                         | `YES`
+`global.gateway.port` | Gateway host port                                                                                                                  | `8443`                                     | `YES`
+`priorityClass.create` | If true priority class will be created                                                                                             | `False`                                    | `NO`
+`priorityClass.name` | Define the name of priority class or default value will be used                                                                    | ``                                         | `NO`
+`priorityClass.preemptionPolicy` | Preemption policy for priority class                                                                                               | `PreemptLowerPriority`                     | `NO`
+`priorityClass.value` | `The integer value of the priority`                                                                                                | `1000000`                                  | `NO`
+`image.repository` | the docker image name to use                                                                                                       | `enforcer`                                 | `YES`
+`image.tag` | The image tag to use.                                                                                                              | `2022.4`                                   | `YES`
+`image.pullPolicy` | The kubernetes image pull policy.                                                                                                  | `Always`                                   | `NO`
+`healthMonitor.enabled` | Enabling health monitoring for enforcer liveness and readiness                                                                     | `true`                                     | `YES`
+`resources` | 	Resource requests and limits                                                                                                      | `{}`                                       | `NO`
+`nodeSelector` | 	Kubernetes node selector	                                                                                                         | `{}`                                       | `NO`
+`tolerations` | 	Kubernetes node tolerations	                                                                                                      | `[]`                                       | `NO`
+`podAnnotations` | Kubernetes pod annotations                                                                                                         | `{}`                                       | `NO`
+`affinity` | 	Kubernetes node affinity                                                                                                          | `{}`                                       | `NO`
+`TLS.enabled` | If require secure channel communication                                                                                            | `false`                                    | `NO`
+`TLS.secretName` | certificates secret name                                                                                                           | `nil`                                      | `YES` <br /> `if TLS.enabled is set to true`
+`TLS.publicKey_fileName` | filename of the public key eg: aqua_enforcer.crt                                                                                   | `nil`                                      |  `YES` <br /> `if TLS.enabled is set to true`
+`TLS.privateKey_fileName`   | filename of the private key eg: aqua_enforcer.key                                                                                  | `nil`                                      |  `YES` <br /> `if TLS.enabled is set to true`
+`TLS.rootCA_fileName` | filename of the rootCA, if using self-signed certificates eg: rootCA.crt                                                           | `nil`                                      |  `NO` <br /> `if TLS.enabled is set to true and using self-signed certificates for TLS/mTLS`
+`TLS.aqua_verify_enforcer` | change it to "1" or "0" for enabling/disabling mTLS between enforcer and ay/envoy                                                  | `0`                                        |  `YES` <br /> `if TLS.enabled is set to true`
+`extraEnvironmentVars` | is a list of extra environment variables to set in the enforcer daemonset.                                                         | `{}`                                       | `NO`
+`extraSecretEnvironmentVars` | is a list of extra environment variables to set in the scanner daemonset, these variables take value from existing Secret objects. | `[]`                                       | `NO`
 
 > Note: that `imageCredentials.create` is false and if you need to create image pull secret please update to true, set the username and password for the registry and `serviceAccount.create` is false and if you're environment is new or not having aqua-sa serviceaccount please update it to true.
 

--- a/enforcer/templates/rbac.yaml
+++ b/enforcer/templates/rbac.yaml
@@ -14,6 +14,13 @@ rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["*"]
   verbs: ["get", "list", "watch"]
+{{- if and (.Values.podSecurityPolicy.create) (le .Capabilities.KubeVersion.Minor "24") }}
+- apiGroups: ["policies"]
+  resources: ["podsecuritypolicies"]
+  verbs: ["use"]
+  resourceNames:
+    - {{ .Release.Name }}-psp
+{{- end }}
 {{- if eq .Values.global.platform "openshift" }}
 - apiGroups: [""]
   resources: ["imagestreams", "imagestreams/layers"]
@@ -41,6 +48,31 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "agentServiceAccount" . }}
     namespace: {{ .Release.Namespace }}
+{{- if and (.Values.podSecurityPolicy.create) (le .Capabilities.KubeVersion.Minor "24") }}
+---
+# PodSecurityPolicy
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Release.Name }}-psp
+  labels:
+    app: {{ .Release.Name }}
+    aqua.component: server
+spec:
+  privileged: {{ .Values.podSecurityPolicy.privileged }}
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+{{- end }}
 ---
 ## Openshift RBAC
 {{- if eq .Values.global.platform "openshift" }}

--- a/enforcer/values.yaml
+++ b/enforcer/values.yaml
@@ -96,6 +96,11 @@ securityContext:
       - SYS_RESOURCE
       - IPC_LOCK
 
+# podsecurity policy [Deprecated from kubernetes version > 1.21]
+podSecurityPolicy:
+  create: false     # Enable to true to create PSP
+  privileged: true
+
 multiple_gateway: # enable this to connect enforcer with multiple gateways
   enabled: false
 # use the below hosts to add multiple gateways as required to enforcer. Format is <hostname>:<port_number>

--- a/server/README.md
+++ b/server/README.md
@@ -345,163 +345,165 @@ helm upgrade --install --namespace aqua <RELEASE_NAME> aqua-helm/server --set im
 
 ## Configurable Variables
 
-Parameter | Description| Default | Mandatory
---------- |------------|---------| ---------
-`imageCredentials.create` | Set if to create new pull image secret| `true` | `YES`
-`imageCredentials.name` | Your Docker pull image secret name    | `aqua-registry-secret`| `YES`
-`imageCredentials.repositoryUriPrefix` | repository uri prefix for dockerhub set `docker.io`         | `registry.aquasec.com`| `YES`
-`imageCredentials.registry` | set the registry url for dockerhub set `index.docker.io/v1/`| `registry.aquasec.com`| `YES`
-`imageCredentials.username` | Your Docker registry (DockerHub, etc.) username| `aqua-registry-secret`| `YES`
-`imageCredentials.password` | Your Docker registry (DockerHub, etc.) password| `unset`| `YES`
-`global.platform` | Orchestration platform name (Allowed values are aks, eks, gke, openshift, tkg, tkgi, k8s, rancher, gs, k3s)| `unset`| `YES`
-`openshift_route.create` | to create openshift routes for web and gateway | `false`| `NO`
-`rbac.create` | to create default cluster-role and cluster-role bindings according to the platform | `true` | `NO`
-`serviceAccount.create`    | Enable to true to create serviceaccount         | `true`  | `YES`
-`serviceAccount.name`      | mention existing service-account name to overwrite the default serviceAccount name, Default is {{ .Release.Namespace }}-sa | `unset` | `NO`
-`clusterRole.roleRef` | cluster role reference name for cluster rolebinding         | `unset`| `NO`
-`activeactive` | set for HA Active-Active cluster mode | `false`
-`clustermode` | set for HA Active-Passive cluster mode <br> To be deprecated, use Active-Active instead     | `false`
-`admin.token`| Use this Aqua license token| `unset`| `NO`
-`admin.password` | Use this Aqua admin password          | `unset`| `NO`
-`dockerSocket.mount` | boolean parameter if to mount docker socket| `unset`| `NO`
-`dockerSocket.path` | docker socket path | `/var/run/docker.sock`| `NO`
-`docker` | Scanning mode direct or docker [link](https://docs.aquasec.com/docs/scanning-mode#default-scanning-mode) | `-`    | `NO`
-`global.db.external.enabled` | Avoid installing a Postgres container and use an external database instead | `false`| `YES`
-`global.db.external.name` | PostgreSQL DB name | `unset`| `YES`<br />`if db.external.enabled is set to true`
-`global.db.external.host` | PostgreSQL DB hostname | `unset`| `YES`<br />`if db.external.enabled is set to true`
-`global.db.external.port` | PostgreSQL DB port | `unset`| `YES`<br />`if db.external.enabled is set to true`
-`global.db.external.user` | PostgreSQL DB username | `unset`| `YES`<br />`if db.external.enabled is set to true`
-`global.db.external.password` | PostgreSQL DB password | `unset`| `YES`<br />`if db.external.enabled is set to true`
-`global.db.external.auditName` | PostgreSQL DB audit name | `unset`| `NO`
-`global.db.external.auditHost` | PostgreSQL DB audit hostname          | `unset`| `NO`
-`global.db.external.auditPort` | PostgreSQL DB audit port | `unset`| `NO`
-`global.db.external.auditUser` | PostgreSQL DB audit username          | `unset`| `NO`
-`global.db.external.auditPassword` | PostgreSQL DB audit password          | `unset`| `NO`
-`global.db.external.pubsubName` | PostgreSQL DB pubsub name| `unset`| `NO`
-`global.db.external.pubsubHost` | PostgreSQL DB pubsub hostname         | `unset`| `NO`
-`global.db.external.pubsubPort` | PostgreSQL DB pubsub port| `unset`| `NO`
-`global.db.external.pubsubUser` | PostgreSQL DB pubsub username         | `unset`| `NO`
-`global.db.external.pubsubPassword` | PostgreSQL DB pubsub password         | `unset`| `NO`
-`global.db.passwordFromSecret.enabled` | Enable to load DB passwords from Secrets | `false`| `YES`
-`global.db.passwordFromSecret.dbPasswordName` | password secret name | `null` | `NO`
-`global.db.passwordFromSecret.dbPasswordKey` | password secret key| `null` | `NO`
-`global.db.passwordFromSecret.dbAuditPasswordName` | Audit password secret name | `null` | `NO`
-`global.db.passwordFromSecret.dbAuditPasswordKey` | Audit password secret key| `null` | `NO`
-`global.db.passwordFromSecret.dbPubsubPasswordName` | Pubsub password secret name| `null` | `NO`
-`global.db.passwordFromSecret.dbPubsubPasswordKey` | Pubsub password secret key | `null` | `NO`
-`global.db.ssl` | If require an SSL-encrypted connection to the Postgres configuration database. | 	`false`      | `NO`
-`global.db.sslmode` | If `ssl` is true, select the type of SSL mode between db and console/gateway  accepts: allow, prefer, require, verify-ca, verify-full (Default: Require) | `require` | `NO`
-`global.db.auditssl` | If require an SSL-encrypted connection to the Postgres configuration audit database.        | 	`false`      | `NO`
-`global.db.auditsslmode` | If `auditssl` is true, select the type of SSL mode between db and console/gateway  accepts: allow, prefer, require, verify-ca, verify-full (Default: Require) | `require` | `NO`
-`global.db.pubsubssl` | If require an SSL-encrypted connection to the Postgres configuration pubsub database.       | 	`false`      | `NO`
-`global.db.pubsubsslmode` | If `pubsubssl` is true, select the type of SSL mode between db and console/gateway  accepts: allow, prefer, require, verify-ca, verify-full (Default: Require) | `require` | `NO`
-`global.db.externalDbCerts.enable` | If true, external db can connect with mTLS i.e.., verify-ca/verify-full ssl mode by mounting the ca cert to console & gateway | `false` | `NO`
-`global.db.externalDbCerts.certSecretName` | If `global.db.externalDbCerts.enable` true, Secret name which holds external db ca certificate files | `null` | `NO`
-`global.db.persistence.database.enabled` | If true, Persistent Volume Claim will be created | 	`true`| `NO`
-`global.db.persistence.database.accessModes` | 	Persistent Volume access mode        | 	`ReadWriteOnce`| `NO`
-`global.db.persistence.database.size` | 	Persistent Volume size| `30Gi` | `NO`
-`global.db.persistence.database.storageClass` | 	Persistent Volume Storage Class      | `unset`| `NO`
-`global.db.persistence.audit_database.enabled` | If true, Persistent Volume Claim will be created for audit database      | 	`true`| `NO`
-`global.db.persistence.audit_database.accessModes` | 	Persistent Volume access mode for audit database| 	`ReadWriteOnce`| `NO`
-`global.db.persistence.audit_database.size` | 	Persistent Volume size for audit database | `30Gi` | `NO`
-`global.db.persistence.audit_database.storageClass` | 	Persistent Volume Storage Class for audit database         | `unset`| `NO`
-`global.db.env_size` | Set this to tune DB parameters        | `S`    | `YES`</br >`Possible values: “S” (default), “M”, “L”`
-`global.db.image.repository` | the docker image name to use          | `database`    | `NO`
-`global.db.image.tag` | The image tag to use.| `2022.4`      | `NO`
-`global.db.image.pullPolicy` | The kubernetes image pull policy.     | `IfNotPresent`| `NO`
-`global.db.service.type` | k8s service type   | `ClusterIP`   | `NO`
-`global.db.resources` | 	Resource requests and limits         | `{}`   | `NO`
-`global.db.nodeSelector` | 	Kubernetes node selector| `{}`   | `NO`
-`global.db.tolerations` | 	Kubernetes node tolerations	         | `[]`   | `NO`
-`global.db.affinity` | 	Kubernetes node affinity| `{}`   | `NO`
-`global.db.podAnnotations` | Kubernetes pod annotations | `{}`   | `NO`
-`global.db.securityContext` | Set of security context for the container| `nil`  | `NO`
-`global.db.extraEnvironmentVars` | is a list of extra environment variables to set in the database deployments. | `{}`   | `NO`
-`global.db.extraSecretEnvironmentVars` | is a list of extra environment variables to set in the database deployments, these variables take value from existing Secret objects.| `[]`   | `NO`
-`gateway.image.repository` | the docker image name to use          | `gateway`     | `NO`
-`gateway.enabled` | Deploy gateway chart with server chart| `True` | `NO`
-`gateway.image.tag` | The image tag to use.| `2022.4`      | `NO`
-`gateway.image.pullPolicy` | The kubernetes image pull policy.     | `IfNotPresent`| `NO`
-`gateway.service.type` | k8s service type   | `ClusterIP`   | `NO`
-`gateway.service.loadbalancerIP` | can specify loadBalancerIP address for aqua-web in AKS platform   | `null` | `NO`
-`gateway.service.annotations` | 	service annotations	| `{}`   | `NO`
-`gateway.service.ports` | array of ports settings| `array`| `NO`
-`gateway.serviceAccount.name` | The name of the SA to deploy the gateway | `aqua-sa`| `NO`
-`gateway.publicIP` | gateway public ip  | `aqua-gateway`| `NO`
-`gateway.replicaCount` | replica count      | `1`    | `NO`
-`gateway.resources` | 	Resource requests and limits         | `{}`   | `NO`
-`gateway.nodeSelector` | 	Kubernetes node selector| `{}`   | `NO`
-`gateway.tolerations` | 	Kubernetes node tolerations	         | `[]`   | `NO`
-`gateway.affinity` | 	Kubernetes node affinity| `{}`   | `NO`
-`gateway.podAnnotations` | Kubernetes pod annotations | `{}`   | `NO`
-`gateway.securityContext` | Set of security context for the container| `nil`  | `NO`
-`gateway.pdb.minAvailable` | Set minimum available value for gate pod PDB | `1`    | `NO`
-`gateway.TLS.enabled` | If require secure channel communication  | `false`| `NO`
-`gateway.TLS.secretName` | certificates secret name | `nil`  | `YES` <br /> `if gate.TLS.enabled is set to true`
-`gateway.TLS.publicKey_fileName` | filename of the public key eg: aqua_gateway.crt| `nil`  |  `YES` <br /> `if gate.TLS.enabled is set to true`
-`gateway.TLS.privateKey_fileName`   | filename of the private key eg: aqua_gateway.key | `nil`  |  `YES` <br /> `if gate.TLS.enabled is set to true`
-`gateway.TLS.rootCA_fileName` | filename of the rootCA, if using self-signed certificates eg: rootCA.crt | `nil`  |  `NO` <br /> `if gate.TLS.enabled is set to true and using self-signed certificates for TLS/mTLS`
-`gateway.TLS.aqua_verify_enforcer` | change it to "1" or "0" for enabling/disabling mTLS between enforcer and gateway/envoy      | `0`    |  `YES` <br /> `if gate.TLS.enabled is set to true`
-`gateway.extraEnvironmentVars` | is a list of extra environment variables to set in the gateway deployments.| `{}`   | `NO`
-`gateway.extraSecretEnvironmentVars` | is a list of extra environment variables to set in the gateway deployments, these variables take value from existing Secret objects. | `[]`   | `NO`
-`gateway.headlessService` | create headless service for envoy     | `true` | `NO`
-`web.image.repository` | the docker image name to use          | `console`     | `NO`
-`web.image.tag` | The image tag to use.| `2022.4`      | `NO`
-`web.image.pullPolicy` | The kubernetes image pull policy.     | `IfNotPresent`| `NO`
-`web.service.type` | k8s service type   | `LoadBalancer`| `NO`
-`web.service.loadbalancerIP` | can specify loadBalancerIP address for aqua-web in AKS platform   | `null` | `NO`
-`web.service.annotations` | 	service annotations	| `{}`   | `NO`
-`web.service.ports` | array of ports settings| `array`| `NO`
-`web.replicaCount` | replica count      | `1`    | `NO`
-`web.resources` | 	Resource requests and limits         | `{}`   | `NO`
-`web.nodeSelector` | 	Kubernetes node selector| `{}`   | `NO`
-`web.tolerations` | 	Kubernetes node tolerations	         | `[]`   | `NO`
-`web.affinity` | 	Kubernetes node affinity| `{}`   | `NO`
-`web.podAnnotations` | Kubernetes pod annotations | `{}`   | `NO`
-`web.ingress.enabled` | 	If true, Ingress will be created     | `false`| `NO`
-`web.ingress.annotations` | 	Ingress annotations	| `[]`   | `NO`
-`web.ingress.hosts` | Ingress hostnames  | 	`[]`  | `NO`
-`web.ingress.path` | 	Ingress Path      | `/`    | `NO`
-`web.ingress.tls` | 	Ingress TLS configuration (YAML)     | `[]`   | `NO`
-`web.securityContext` | Set of security context for the container| `nil`  | `NO`
-`web.pdb.minAvailable` | Set minimum available value for web pod PDB| `1`    | `NO`
-`web.TLS.enabled` | If require secure channel communication  | `false`| `NO`
-`web.TLS.secretName` | certificates secret name | `nil`  | `NO`
-`web.TLS.publicKey_fileName` | filename of the public key eg: aqua_web.crt| `nil`  |  `YES` <br /> `if gate.TLS.enabled is set to true`
-`web.TLS.privateKey_fileName`   | filename of the private key eg: aqua_web.key | `nil`  |  `YES` <br /> `if gate.TLS.enabled is set to true`
-`web.TLS.rootCA_fileName` | filename of the rootCA, if using self-signed certificates eg: rootCA.crt | `nil`  |  `NO` <br /> `if gate.TLS.enabled is set to true and using self-signed certificates for TLS/mTLS`
-`web.maintenance_db.name` | If Configured to use custom maintenance DB specify the DB name    | `unset`| `NO`
-`web.extraEnvironmentVars` | is a list of extra environment variables to set in the web deployments.  | `{}`   | `NO`
-`web.extraSecretEnvironmentVars` | is a list of extra environment variables to set in the web deployments, these variables take value from existing Secret objects. | `[]`   | `NO`
-`envoy.enabled` | enabled envoy deployment.| `false`| `NO`
-`envoy.replicaCount` | replica count      | `1`    | `NO`
-`envoy.image.repository` | the docker image name to use          | `envoyproxy/envoy-alpine`        | `NO`
-`envoy.image.tag` | The image tag to use.| `v1.14.1`     | `NO`
-`envoy.image.pullPolicy` | The kubernetes image pull policy.     | `IfNotPresent`| `NO`
-`envoy.service.type` | k8s service type   | `LoadBalancer`| `NO`
-`envoy.service.loadbalancerIP` | can specify loadBalancerIP address for aqua-web in AKS platform   | `null` | `NO`
+Parameter | Description                                                                                                                                                                                         | Default | Mandatory
+--------- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------| ---------
+`imageCredentials.create` | Set if to create new pull image secret                                                                                                                                                              | `true` | `YES`
+`imageCredentials.name` | Your Docker pull image secret name                                                                                                                                                                  | `aqua-registry-secret`| `YES`
+`imageCredentials.repositoryUriPrefix` | repository uri prefix for dockerhub set `docker.io`                                                                                                                                                 | `registry.aquasec.com`| `YES`
+`imageCredentials.registry` | set the registry url for dockerhub set `index.docker.io/v1/`                                                                                                                                        | `registry.aquasec.com`| `YES`
+`imageCredentials.username` | Your Docker registry (DockerHub, etc.) username                                                                                                                                                     | `aqua-registry-secret`| `YES`
+`imageCredentials.password` | Your Docker registry (DockerHub, etc.) password                                                                                                                                                     | `unset`| `YES`
+`global.platform` | Orchestration platform name (Allowed values are aks, eks, gke, openshift, tkg, tkgi, k8s, rancher, gs, k3s)                                                                                         | `unset`| `YES`
+`openshift_route.create` | to create openshift routes for web and gateway                                                                                                                                                      | `false`| `NO`
+`rbac.create` | to create default cluster-role and cluster-role bindings according to the platform                                                                                                                  | `true` | `NO`
+`serviceAccount.create`    | Enable to true to create serviceaccount                                                                                                                                                             | `true`  | `YES`
+`serviceAccount.name`      | mention existing service-account name to overwrite the default serviceAccount name, Default is {{ .Release.Namespace }}-sa                                                                          | `unset` | `NO`
+`clusterRole.roleRef` | cluster role reference name for cluster rolebinding                                                                                                                                                 | `unset`| `NO`
+`activeactive` | set for HA Active-Active cluster mode                                                                                                                                                               | `false`
+`clustermode` | set for HA Active-Passive cluster mode <br> To be deprecated, use Active-Active instead                                                                                                             | `false`
+`admin.token`| Use this Aqua license token                                                                                                                                                                         | `unset`| `NO`
+`admin.password` | Use this Aqua admin password                                                                                                                                                                        | `unset`| `NO`
+`dockerSocket.mount` | boolean parameter if to mount docker socket                                                                                                                                                         | `unset`| `NO`
+`dockerSocket.path` | docker socket path                                                                                                                                                                                  | `/var/run/docker.sock`| `NO`
+`podSecurityPolicy.create` | Enable Pod Security Policies with the required Server capabilities                                                                                                                                  | `false`                                    | `NO`
+`podSecurityPolicy.privileged` | Enable privileged permissions to the Server                                                                                                                                                         | `true` if podSecurityPolicy.create is `true` | `NO`
+`docker` | Scanning mode direct or docker [link](https://docs.aquasec.com/docs/scanning-mode#default-scanning-mode)                                                                                            | `-`    | `NO`
+`global.db.external.enabled` | Avoid installing a Postgres container and use an external database instead                                                                                                                          | `false`| `YES`
+`global.db.external.name` | PostgreSQL DB name                                                                                                                                                                                  | `unset`| `YES`<br />`if db.external.enabled is set to true`
+`global.db.external.host` | PostgreSQL DB hostname                                                                                                                                                                              | `unset`| `YES`<br />`if db.external.enabled is set to true`
+`global.db.external.port` | PostgreSQL DB port                                                                                                                                                                                  | `unset`| `YES`<br />`if db.external.enabled is set to true`
+`global.db.external.user` | PostgreSQL DB username                                                                                                                                                                              | `unset`| `YES`<br />`if db.external.enabled is set to true`
+`global.db.external.password` | PostgreSQL DB password                                                                                                                                                                              | `unset`| `YES`<br />`if db.external.enabled is set to true`
+`global.db.external.auditName` | PostgreSQL DB audit name                                                                                                                                                                            | `unset`| `NO`
+`global.db.external.auditHost` | PostgreSQL DB audit hostname                                                                                                                                                                        | `unset`| `NO`
+`global.db.external.auditPort` | PostgreSQL DB audit port                                                                                                                                                                            | `unset`| `NO`
+`global.db.external.auditUser` | PostgreSQL DB audit username                                                                                                                                                                        | `unset`| `NO`
+`global.db.external.auditPassword` | PostgreSQL DB audit password                                                                                                                                                                        | `unset`| `NO`
+`global.db.external.pubsubName` | PostgreSQL DB pubsub name                                                                                                                                                                           | `unset`| `NO`
+`global.db.external.pubsubHost` | PostgreSQL DB pubsub hostname                                                                                                                                                                       | `unset`| `NO`
+`global.db.external.pubsubPort` | PostgreSQL DB pubsub port                                                                                                                                                                           | `unset`| `NO`
+`global.db.external.pubsubUser` | PostgreSQL DB pubsub username                                                                                                                                                                       | `unset`| `NO`
+`global.db.external.pubsubPassword` | PostgreSQL DB pubsub password                                                                                                                                                                       | `unset`| `NO`
+`global.db.passwordFromSecret.enabled` | Enable to load DB passwords from Secrets                                                                                                                                                            | `false`| `YES`
+`global.db.passwordFromSecret.dbPasswordName` | password secret name                                                                                                                                                                                | `null` | `NO`
+`global.db.passwordFromSecret.dbPasswordKey` | password secret key                                                                                                                                                                                 | `null` | `NO`
+`global.db.passwordFromSecret.dbAuditPasswordName` | Audit password secret name                                                                                                                                                                          | `null` | `NO`
+`global.db.passwordFromSecret.dbAuditPasswordKey` | Audit password secret key                                                                                                                                                                           | `null` | `NO`
+`global.db.passwordFromSecret.dbPubsubPasswordName` | Pubsub password secret name                                                                                                                                                                         | `null` | `NO`
+`global.db.passwordFromSecret.dbPubsubPasswordKey` | Pubsub password secret key                                                                                                                                                                          | `null` | `NO`
+`global.db.ssl` | If require an SSL-encrypted connection to the Postgres configuration database.                                                                                                                      | 	`false`      | `NO`
+`global.db.sslmode` | If `ssl` is true, select the type of SSL mode between db and console/gateway  accepts: allow, prefer, require, verify-ca, verify-full (Default: Require)                                            | `require` | `NO`
+`global.db.auditssl` | If require an SSL-encrypted connection to the Postgres configuration audit database.                                                                                                                | 	`false`      | `NO`
+`global.db.auditsslmode` | If `auditssl` is true, select the type of SSL mode between db and console/gateway  accepts: allow, prefer, require, verify-ca, verify-full (Default: Require)                                       | `require` | `NO`
+`global.db.pubsubssl` | If require an SSL-encrypted connection to the Postgres configuration pubsub database.                                                                                                               | 	`false`      | `NO`
+`global.db.pubsubsslmode` | If `pubsubssl` is true, select the type of SSL mode between db and console/gateway  accepts: allow, prefer, require, verify-ca, verify-full (Default: Require)                                      | `require` | `NO`
+`global.db.externalDbCerts.enable` | If true, external db can connect with mTLS i.e.., verify-ca/verify-full ssl mode by mounting the ca cert to console & gateway                                                                       | `false` | `NO`
+`global.db.externalDbCerts.certSecretName` | If `global.db.externalDbCerts.enable` true, Secret name which holds external db ca certificate files                                                                                                | `null` | `NO`
+`global.db.persistence.database.enabled` | If true, Persistent Volume Claim will be created                                                                                                                                                    | 	`true`| `NO`
+`global.db.persistence.database.accessModes` | 	Persistent Volume access mode                                                                                                                                                                      | 	`ReadWriteOnce`| `NO`
+`global.db.persistence.database.size` | 	Persistent Volume size                                                                                                                                                                             | `30Gi` | `NO`
+`global.db.persistence.database.storageClass` | 	Persistent Volume Storage Class                                                                                                                                                                    | `unset`| `NO`
+`global.db.persistence.audit_database.enabled` | If true, Persistent Volume Claim will be created for audit database                                                                                                                                 | 	`true`| `NO`
+`global.db.persistence.audit_database.accessModes` | 	Persistent Volume access mode for audit database                                                                                                                                                   | 	`ReadWriteOnce`| `NO`
+`global.db.persistence.audit_database.size` | 	Persistent Volume size for audit database                                                                                                                                                          | `30Gi` | `NO`
+`global.db.persistence.audit_database.storageClass` | 	Persistent Volume Storage Class for audit database                                                                                                                                                 | `unset`| `NO`
+`global.db.env_size` | Set this to tune DB parameters                                                                                                                                                                      | `S`    | `YES`</br >`Possible values: “S” (default), “M”, “L”`
+`global.db.image.repository` | the docker image name to use                                                                                                                                                                        | `database`    | `NO`
+`global.db.image.tag` | The image tag to use.                                                                                                                                                                               | `2022.4`      | `NO`
+`global.db.image.pullPolicy` | The kubernetes image pull policy.                                                                                                                                                                   | `IfNotPresent`| `NO`
+`global.db.service.type` | k8s service type                                                                                                                                                                                    | `ClusterIP`   | `NO`
+`global.db.resources` | 	Resource requests and limits                                                                                                                                                                       | `{}`   | `NO`
+`global.db.nodeSelector` | 	Kubernetes node selector                                                                                                                                                                           | `{}`   | `NO`
+`global.db.tolerations` | 	Kubernetes node tolerations	                                                                                                                                                                       | `[]`   | `NO`
+`global.db.affinity` | 	Kubernetes node affinity                                                                                                                                                                           | `{}`   | `NO`
+`global.db.podAnnotations` | Kubernetes pod annotations                                                                                                                                                                          | `{}`   | `NO`
+`global.db.securityContext` | Set of security context for the container                                                                                                                                                           | `nil`  | `NO`
+`global.db.extraEnvironmentVars` | is a list of extra environment variables to set in the database deployments.                                                                                                                        | `{}`   | `NO`
+`global.db.extraSecretEnvironmentVars` | is a list of extra environment variables to set in the database deployments, these variables take value from existing Secret objects.                                                               | `[]`   | `NO`
+`gateway.image.repository` | the docker image name to use                                                                                                                                                                        | `gateway`     | `NO`
+`gateway.enabled` | Deploy gateway chart with server chart                                                                                                                                                              | `True` | `NO`
+`gateway.image.tag` | The image tag to use.                                                                                                                                                                               | `2022.4`      | `NO`
+`gateway.image.pullPolicy` | The kubernetes image pull policy.                                                                                                                                                                   | `IfNotPresent`| `NO`
+`gateway.service.type` | k8s service type                                                                                                                                                                                    | `ClusterIP`   | `NO`
+`gateway.service.loadbalancerIP` | can specify loadBalancerIP address for aqua-web in AKS platform                                                                                                                                     | `null` | `NO`
+`gateway.service.annotations` | 	service annotations	                                                                                                                                                                               | `{}`   | `NO`
+`gateway.service.ports` | array of ports settings                                                                                                                                                                             | `array`| `NO`
+`gateway.serviceAccount.name` | The name of the SA to deploy the gateway                                                                                                                                                            | `aqua-sa`| `NO`
+`gateway.publicIP` | gateway public ip                                                                                                                                                                                   | `aqua-gateway`| `NO`
+`gateway.replicaCount` | replica count                                                                                                                                                                                       | `1`    | `NO`
+`gateway.resources` | 	Resource requests and limits                                                                                                                                                                       | `{}`   | `NO`
+`gateway.nodeSelector` | 	Kubernetes node selector                                                                                                                                                                           | `{}`   | `NO`
+`gateway.tolerations` | 	Kubernetes node tolerations	                                                                                                                                                                       | `[]`   | `NO`
+`gateway.affinity` | 	Kubernetes node affinity                                                                                                                                                                           | `{}`   | `NO`
+`gateway.podAnnotations` | Kubernetes pod annotations                                                                                                                                                                          | `{}`   | `NO`
+`gateway.securityContext` | Set of security context for the container                                                                                                                                                           | `nil`  | `NO`
+`gateway.pdb.minAvailable` | Set minimum available value for gate pod PDB                                                                                                                                                        | `1`    | `NO`
+`gateway.TLS.enabled` | If require secure channel communication                                                                                                                                                             | `false`| `NO`
+`gateway.TLS.secretName` | certificates secret name                                                                                                                                                                            | `nil`  | `YES` <br /> `if gate.TLS.enabled is set to true`
+`gateway.TLS.publicKey_fileName` | filename of the public key eg: aqua_gateway.crt                                                                                                                                                     | `nil`  |  `YES` <br /> `if gate.TLS.enabled is set to true`
+`gateway.TLS.privateKey_fileName`   | filename of the private key eg: aqua_gateway.key                                                                                                                                                    | `nil`  |  `YES` <br /> `if gate.TLS.enabled is set to true`
+`gateway.TLS.rootCA_fileName` | filename of the rootCA, if using self-signed certificates eg: rootCA.crt                                                                                                                            | `nil`  |  `NO` <br /> `if gate.TLS.enabled is set to true and using self-signed certificates for TLS/mTLS`
+`gateway.TLS.aqua_verify_enforcer` | change it to "1" or "0" for enabling/disabling mTLS between enforcer and gateway/envoy                                                                                                              | `0`    |  `YES` <br /> `if gate.TLS.enabled is set to true`
+`gateway.extraEnvironmentVars` | is a list of extra environment variables to set in the gateway deployments.                                                                                                                         | `{}`   | `NO`
+`gateway.extraSecretEnvironmentVars` | is a list of extra environment variables to set in the gateway deployments, these variables take value from existing Secret objects.                                                                | `[]`   | `NO`
+`gateway.headlessService` | create headless service for envoy                                                                                                                                                                   | `true` | `NO`
+`web.image.repository` | the docker image name to use                                                                                                                                                                        | `console`     | `NO`
+`web.image.tag` | The image tag to use.                                                                                                                                                                               | `2022.4`      | `NO`
+`web.image.pullPolicy` | The kubernetes image pull policy.                                                                                                                                                                   | `IfNotPresent`| `NO`
+`web.service.type` | k8s service type                                                                                                                                                                                    | `LoadBalancer`| `NO`
+`web.service.loadbalancerIP` | can specify loadBalancerIP address for aqua-web in AKS platform                                                                                                                                     | `null` | `NO`
+`web.service.annotations` | 	service annotations	                                                                                                                                                                               | `{}`   | `NO`
+`web.service.ports` | array of ports settings                                                                                                                                                                             | `array`| `NO`
+`web.replicaCount` | replica count                                                                                                                                                                                       | `1`    | `NO`
+`web.resources` | 	Resource requests and limits                                                                                                                                                                       | `{}`   | `NO`
+`web.nodeSelector` | 	Kubernetes node selector                                                                                                                                                                           | `{}`   | `NO`
+`web.tolerations` | 	Kubernetes node tolerations	                                                                                                                                                                       | `[]`   | `NO`
+`web.affinity` | 	Kubernetes node affinity                                                                                                                                                                           | `{}`   | `NO`
+`web.podAnnotations` | Kubernetes pod annotations                                                                                                                                                                          | `{}`   | `NO`
+`web.ingress.enabled` | 	If true, Ingress will be created                                                                                                                                                                   | `false`| `NO`
+`web.ingress.annotations` | 	Ingress annotations	                                                                                                                                                                               | `[]`   | `NO`
+`web.ingress.hosts` | Ingress hostnames                                                                                                                                                                                   | 	`[]`  | `NO`
+`web.ingress.path` | 	Ingress Path                                                                                                                                                                                       | `/`    | `NO`
+`web.ingress.tls` | 	Ingress TLS configuration (YAML)                                                                                                                                                                   | `[]`   | `NO`
+`web.securityContext` | Set of security context for the container                                                                                                                                                           | `nil`  | `NO`
+`web.pdb.minAvailable` | Set minimum available value for web pod PDB                                                                                                                                                         | `1`    | `NO`
+`web.TLS.enabled` | If require secure channel communication                                                                                                                                                             | `false`| `NO`
+`web.TLS.secretName` | certificates secret name                                                                                                                                                                            | `nil`  | `NO`
+`web.TLS.publicKey_fileName` | filename of the public key eg: aqua_web.crt                                                                                                                                                         | `nil`  |  `YES` <br /> `if gate.TLS.enabled is set to true`
+`web.TLS.privateKey_fileName`   | filename of the private key eg: aqua_web.key                                                                                                                                                        | `nil`  |  `YES` <br /> `if gate.TLS.enabled is set to true`
+`web.TLS.rootCA_fileName` | filename of the rootCA, if using self-signed certificates eg: rootCA.crt                                                                                                                            | `nil`  |  `NO` <br /> `if gate.TLS.enabled is set to true and using self-signed certificates for TLS/mTLS`
+`web.maintenance_db.name` | If Configured to use custom maintenance DB specify the DB name                                                                                                                                      | `unset`| `NO`
+`web.extraEnvironmentVars` | is a list of extra environment variables to set in the web deployments.                                                                                                                             | `{}`   | `NO`
+`web.extraSecretEnvironmentVars` | is a list of extra environment variables to set in the web deployments, these variables take value from existing Secret objects.                                                                    | `[]`   | `NO`
+`envoy.enabled` | enabled envoy deployment.                                                                                                                                                                           | `false`| `NO`
+`envoy.replicaCount` | replica count                                                                                                                                                                                       | `1`    | `NO`
+`envoy.image.repository` | the docker image name to use                                                                                                                                                                        | `envoyproxy/envoy-alpine`        | `NO`
+`envoy.image.tag` | The image tag to use.                                                                                                                                                                               | `v1.14.1`     | `NO`
+`envoy.image.pullPolicy` | The kubernetes image pull policy.                                                                                                                                                                   | `IfNotPresent`| `NO`
+`envoy.service.type` | k8s service type                                                                                                                                                                                    | `LoadBalancer`| `NO`
+`envoy.service.loadbalancerIP` | can specify loadBalancerIP address for aqua-web in AKS platform                                                                                                                                     | `null` | `NO`
 `envoy.service.annotations` | use this field to pass additional annotations for the service, useful to drive Cloud providers behaviour in creating the LB resource. E.g. `service.beta.kubernetes.io/aws-load-balancer-type: nlb` | `{}`   | `NO`
-`envoy.service.ports` | array of ports settings| `array`| `NO`
-`envoy.pdb.minAvailable` | Set minimum available value for envoy pod PDB| `1`    | `NO`
-`envoy.TLS.listener.enabled` | enable to load custom self-signed or CA certs| `false`| `NO` <br /> `if envoy.enabled is set to true`
-`envoy.TLS.listener.secretName` | certificates secret name | `nil`  | `NO` <br /> `if envoy.enabled is set to true`
-`envoy.TLS.listener.publicKey_fileName` | filename of the public key eg: aqua-lb.fqdn.crt| `nil`  |  `YES` <br /> `if envoy.enabled is set to true`
-`envoy.TLS.listener.privateKey_fileName`   | filename of the private key eg: aqua-lb.fqdn.key | `nil`  |  `YES` <br /> `if envoy.enabled is set to true`
-`envoy.TLS.listener.rootCA_fileName` | filename of the rootCA, if using self-signed certificates eg: rootCA.crt | `nil`  |  `NO`
-`envoy.TLS.cluster.enabled` | If require secure channel communication between Envoy and Gateway | `false`| `NO`
-`envoy.TLS.cluster.secretName` | certificates secret name | `nil`  | `NO`
-`envoy.TLS.cluster.publicKey_fileName` | filename of the public key eg: aqua-lb.crt | `nil`  |  `NO`
-`envoy.TLS.cluster.privateKey_fileName`   | filename of the private key eg: aqua-lb.key| `nil`  |  `NO`
-`envoy.TLS.cluster.rootCA_fileName` | filename of the rootCA, if using self-signed certificates eg: rootCA.crt | `nil`  |  `NO`
-`envoy.livenessProbe` | liveness probes configuration for envoy  | `{}`   | `NO`
-`envoy.readinessProbe` | readiness probes configuration for envoy | `{}`   | `NO`
-`envoy.resources` | 	Resource requests and limits         | `{}`   | `NO`
-`envoy.nodeSelector` | 	Kubernetes node selector| `{}`   | `NO`
-`envoy.tolerations` | 	Kubernetes node tolerations	         | `[]`   | `NO`
-`envoy.podAnnotations` | Kubernetes pod annotations | `{}`   | `NO`
-`envoy.affinity` | 	Kubernetes node affinity| `{}`   | `NO`
-`envoy.securityContext` | Set of security context for the container| `nil`  | `NO`
-`envoy.files.envoy.yaml` | content of a full envoy configuration file as documented in https://www.envoyproxy.io/docs/envoy/latest/configuration/configuration| check [values.yaml](values.yaml)
+`envoy.service.ports` | array of ports settings                                                                                                                                                                             | `array`| `NO`
+`envoy.pdb.minAvailable` | Set minimum available value for envoy pod PDB                                                                                                                                                       | `1`    | `NO`
+`envoy.TLS.listener.enabled` | enable to load custom self-signed or CA certs                                                                                                                                                       | `false`| `NO` <br /> `if envoy.enabled is set to true`
+`envoy.TLS.listener.secretName` | certificates secret name                                                                                                                                                                            | `nil`  | `NO` <br /> `if envoy.enabled is set to true`
+`envoy.TLS.listener.publicKey_fileName` | filename of the public key eg: aqua-lb.fqdn.crt                                                                                                                                                     | `nil`  |  `YES` <br /> `if envoy.enabled is set to true`
+`envoy.TLS.listener.privateKey_fileName`   | filename of the private key eg: aqua-lb.fqdn.key                                                                                                                                                    | `nil`  |  `YES` <br /> `if envoy.enabled is set to true`
+`envoy.TLS.listener.rootCA_fileName` | filename of the rootCA, if using self-signed certificates eg: rootCA.crt                                                                                                                            | `nil`  |  `NO`
+`envoy.TLS.cluster.enabled` | If require secure channel communication between Envoy and Gateway                                                                                                                                   | `false`| `NO`
+`envoy.TLS.cluster.secretName` | certificates secret name                                                                                                                                                                            | `nil`  | `NO`
+`envoy.TLS.cluster.publicKey_fileName` | filename of the public key eg: aqua-lb.crt                                                                                                                                                          | `nil`  |  `NO`
+`envoy.TLS.cluster.privateKey_fileName`   | filename of the private key eg: aqua-lb.key                                                                                                                                                         | `nil`  |  `NO`
+`envoy.TLS.cluster.rootCA_fileName` | filename of the rootCA, if using self-signed certificates eg: rootCA.crt                                                                                                                            | `nil`  |  `NO`
+`envoy.livenessProbe` | liveness probes configuration for envoy                                                                                                                                                             | `{}`   | `NO`
+`envoy.readinessProbe` | readiness probes configuration for envoy                                                                                                                                                            | `{}`   | `NO`
+`envoy.resources` | 	Resource requests and limits                                                                                                                                                                       | `{}`   | `NO`
+`envoy.nodeSelector` | 	Kubernetes node selector                                                                                                                                                                           | `{}`   | `NO`
+`envoy.tolerations` | 	Kubernetes node tolerations	                                                                                                                                                                       | `[]`   | `NO`
+`envoy.podAnnotations` | Kubernetes pod annotations                                                                                                                                                                          | `{}`   | `NO`
+`envoy.affinity` | 	Kubernetes node affinity                                                                                                                                                                           | `{}`   | `NO`
+`envoy.securityContext` | Set of security context for the container                                                                                                                                                           | `nil`  | `NO`
+`envoy.files.envoy.yaml` | content of a full envoy configuration file as documented in https://www.envoyproxy.io/docs/envoy/latest/configuration/configuration                                                                 | check [values.yaml](values.yaml)
 
 ## Issues and feedback
 

--- a/server/templates/rbac.yaml
+++ b/server/templates/rbac.yaml
@@ -19,6 +19,13 @@ rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["*"]
   verbs: ["get", "list", "watch"]
+{{- if and (.Values.podSecurityPolicy.create) (le .Capabilities.KubeVersion.Minor "24") }}
+- apiGroups: ["policies"]
+  resources: ["podsecuritypolicies"]
+  verbs: ["use"]
+  resourceNames:
+    - {{ .Release.Name }}-psp
+{{- end }}
 {{- if eq .Values.global.platform "openshift" }}
 - apiGroups: [""]
   resources: ["imagestreams", "imagestreams/layers"]
@@ -46,7 +53,7 @@ subjects:
   - kind: ServiceAccount
     namespace: {{ .Release.Namespace }}
     name: {{ template "server.serviceAccount" . }}
-{{- if and (.Values.podSecurityPolicy.create) (le .Capabilities.KubeVersion.Minor "21") }}
+{{- if and (.Values.podSecurityPolicy.create) (le .Capabilities.KubeVersion.Minor "24") }}
 ---
 # PodSecurityPolicy
 apiVersion: policy/v1beta1
@@ -71,8 +78,6 @@ spec:
   volumes:
   - '*'
 {{- end }}
-
-
 {{- if eq .Values.global.platform "tkg" }}
 ## TKG RBAC
 ---

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -46,7 +46,7 @@ dockerSock:
 
 nameOverride: ""
 
-# podsecurity policy [Deprecated from kubernetes version < 1.21]
+# podsecurity policy [Deprecated from kubernetes version > 1.21]
 podSecurityPolicy:
   create: false     # Enable to true to create PSP
   privileged: true


### PR DESCRIPTION
Porting psp to enforcer chart (server doesn't actually need this)
Fixing PSP for server, adding "use" verb to cluster role (otherwise the component is not going to be able to use the PSP

thanks to @morgantatkins for helping with this