### PR TITLE
2022.4 | Kubeenforcer | Fix issue with starboard rolebinding not following custom namespace

### DIFF
--- a/kube-enforcer/CHANGELOG.md
+++ b/kube-enforcer/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## 2022.4.15 ( Jan 27, 2023 )
+* Fixed issue with Starboard to deploy in custom namespace
+
 ## 2022.4.14 ( Jan 9, 2023 )
 * Added new openshift-scc for kube-enforcer.
 * Modify the default kube-enforcer service account name.

--- a/kube-enforcer/Chart.yaml
+++ b/kube-enforcer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2022.4"
 description: A Helm chart for the Aqua KubeEnforcer Starboard
 name: kube-enforcer
-version: "2022.4.14"
+version: "2022.4.15"
 dependencies:
   - name: enforcer
     version: "2022.4.9"

--- a/kube-enforcer/templates/rolebinding.yaml
+++ b/kube-enforcer/templates/rolebinding.yaml
@@ -29,4 +29,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: starboard-operator
-    namespace: aqua
+    namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Starboard can't deploy to custom namespaces due to issue with hardcode "aqua" namespace in rolebinding, making it impossible for starboard to create secrets.