### PR TITLE
Allow the ApiVersion of the ingress to be specified for 6.5 branch

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -10,6 +10,9 @@ These are Helm charts for installation and maintenance of Aqua Container Securit
   - [Contents](#contents)
   - [Prerequisites](#prerequisites)
     - [Container Registry Credentials](#container-registry-credentials)
+    - [Service Account](#service-account)
+- [Create the ServiceAccount](#create-the-serviceaccount)
+- [Patch the ServiceAccount with the pull secret](#patch-the-serviceaccount-with-the-pull-secret)
     - [PostgreSQL database](#postgresql-database)
   - [Installing the Chart](#installing-the-chart)
     - [Installing Aqua Web from Helm Private Repository](#installing-aqua-web-from-helm-private-repository)
@@ -436,6 +439,7 @@ helm upgrade --install --namespace aqua <RELEASE_NAME> aqua-helm/server --set im
 | `web.podAnnotations`                                | Kubernetes pod annotations  | `{}` | `NO`
 | `web.podLabels`                                     | Configure pod labels        | `{}`| `NO`
 | `web.ingress.enabled`                               | If true, Ingress will be created                       | `false`| `NO`
+|`web.ingress.apiVersion`                             | Override the API version of the Ingress. | ``| `NO`
 | `web.ingress.annotations`                           | Ingress annotations	       | `[]`| `NO`
 | `web.ingress.hosts`                                 | Ingress hostnames           |	`[]`| `NO`
 | `web.ingress.path`                                  | Ingress Path               | `/`| `NO`

--- a/server/templates/web-ingress.yaml
+++ b/server/templates/web-ingress.yaml
@@ -4,12 +4,16 @@
 {{- $ingressPath := .Values.web.ingress.path -}}
 {{- $pathType := .Values.web.ingress.pathType -}}
 ---
+{{- if .Values.web.ingress.apiVersion -}}
+apiVersion: {{ .Values.web.ingress.apiVersion }}
+{{- else -}}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
 apiVersion: networking.k8s.io/v1
 {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 {{- end }}
 kind: Ingress
 metadata:
@@ -44,7 +48,7 @@ spec:
               {{- end }}
     {{- end -}}
   {{ else }}
-  {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+  {{- if or ($.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") (eq .Values.web.ingress.apiVersion "networking.k8s.io/v1/Ingress") }}
   defaultBackend:
     service:
       name: {{ $fullname }}-console-svc

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -334,6 +334,9 @@ web:
         protocol: TCP
   ingress:
     enabled: false
+    # Allows you to specify the API version for the Ingesss 
+    # This is useful where .Capabilities.APIVersions.Has does not work e.g. Helm template & ArgoCD
+    apiVersion:
     externalPort:
     annotations: {}
     #  kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
This is a backport of #697

When using ArgoCD to apply the helm chart to clusters > k8 1.22 the wrong ingress type is being rendered extensions/v1beta1 is being used rather than 'networking.k8s.io/v1'

This happens because under the hood ArgoCD runs helm template and applies the resulting yaml to the cluster. Currently Argo does not pass --validate when doing the helm template which means the .Capabilities.APIVersions.has calls don't work see https://github.com/helm/helm/issues/10760 and https://github.com/argoproj/argo-cd/issues/3640

This PR allows the APIVersion to be overridden in the values

We are currently working around this by turning off the Ingress in the chart and creating our own