### PR TITLE
Update gate-headless-service.yaml

### DIFF
--- a/gateway/templates/gate-headless-service.yaml
+++ b/gateway/templates/gate-headless-service.yaml
@@ -19,9 +19,6 @@ spec:
     - name: {{ $port.name }}
       port: {{ $port.port }}
       targetPort: {{ $port.targetPort }}
-      {{- if $port.nodePort }}
-      nodePort: {{ $port.nodePort }}
-      {{- end }}
       {{- if $port.protocol }}
       protocol: {{ $port.protocol }}
       {{- end }}


### PR DESCRIPTION
removed NodePort in order to resolve https://github.com/aquasecurity/aqua-helm/issues/705