### PR TITLE
- enforcer resources cannot be overriden when in expressMode

### DIFF
--- a/enforcer/templates/enforcer-daemonset.yaml
+++ b/enforcer/templates/enforcer-daemonset.yaml
@@ -159,7 +159,7 @@ spec:
 {{ toYaml . | indent 10 }}
 {{- end }}
 {{- end }}
-        {{- if .Values.expressMode }}
+        {{- if ( and .Values.expressMode ( not .Values.resources ))}}
         resources:
           requests:
             cpu: "500m"


### PR DESCRIPTION
Setting expressMode in deployment of enforcer prevent "resources" to be set by user