### PR TITLE
Enhanced admin secret usage

### DIFF
--- a/server/templates/web-deployment.yaml
+++ b/server/templates/web-deployment.yaml
@@ -108,18 +108,18 @@ spec:
         - name: SSL_CERT_DIR
           value: "/etc/ext_db_certs:/etc/ssl/certs"
         {{- end }}
-        {{- if .Values.admin.token }}
+        {{- if .Values.adminCredentials.enabled }}
         - name: LICENSE_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{ .Release.Name }}-console-secrets
+              name: {{ .Values.adminCredentials.name }}
               key: license-token
         {{- end }}
-        {{- if .Values.admin.password }}
+        {{- if .Values.adminCredentials.enabled }}
         - name: ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Release.Name }}-console-secrets
+              name: {{ .Values.adminCredentials.name }}
               key: admin-password
         {{- end }}
         {{- include "server.extraEnvironmentVars" .Values.web | nindent 8 }}

--- a/server/templates/web-secrets.yaml
+++ b/server/templates/web-secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.adminCredentials.create -}}
 {{- if or (.Values.admin.password) (.Values.admin.token) }}
 ---
 apiVersion: v1
@@ -16,5 +17,6 @@ data:
 {{- end }}
 {{- if .Values.admin.token }}
   license-token: {{ .Values.admin.token | b64enc | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -34,7 +34,10 @@ serviceAccount:
 clustermode: ""
 activeactive: ""
 
-admin:
+adminCredentials:
+  enabled: true
+  create: false
+  name: aqua-console-secrets
   token: ""
   password: ""
 


### PR DESCRIPTION
Enhanced the use of admin creds. 

* You can enable/disable if you want to pass admin-password and licence-token
* Admin creds secret creation is optional now
* You can pass secret name as value

```
adminCredentials:
  enabled: true
  create: false
  name: aqua-console-secrets
  token: ""
  password: ""
```

Fixes https://github.com/aquasecurity/aqua-helm/issues/721