### PR TITLE
change standard name for gateway serviceaccount

### DIFF
--- a/gateway/templates/_helpers.tpl
+++ b/gateway/templates/_helpers.tpl
@@ -72,7 +72,7 @@ And will be used serviceAccount created by parrent chart
 {{- printf "%s" .Values.serviceAccount.name -}}
 {{- else -}}
 {{- if not .Values.serviceAccount.create -}}
-{{- printf "%s-sa" .Release.Namespace -}}
+{{- printf "aqua-sa" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
If deploying aqua server helm chart in an other namespace than "aqua", the service account name has to be specified in values.yaml of aqua server helm chart:
https://github.com/aquasecurity/aqua-helm/blob/2022.4/server/values.yaml#L207


Server helm chart is using "aqua-sa" as the default serviceaccount:
https://github.com/aquasecurity/aqua-helm/blob/d53355f72fb2c26ea7bf21e418a4f4b82d9c031f/server/templates/_helpers.tpl#L30-L31

But gateway helm chart, which is a dependency of server chart, will create a serviceaccount including the namespace:
https://github.com/aquasecurity/aqua-helm/blob/d53355f72fb2c26ea7bf21e418a4f4b82d9c031f/gateway/templates/_helpers.tpl#L75

Because of this, it would simplify a standard deployment, if gateway chart uses "aqua-sa" as the standard serviceaccount name, if not specified otherwise.