### PR TITLE
feat(kube-enforcer): Add ability to define extraVolumes

### DIFF
--- a/kube-enforcer/templates/kube-enforcer-deployment.yaml
+++ b/kube-enforcer/templates/kube-enforcer-deployment.yaml
@@ -104,6 +104,9 @@ spec:
           resources: {{ toYaml .Values.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
+            {{- with .Values.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
             - name: "certs"
               mountPath: "/certs"
 {{- if .Values.kubeEnforcerAdvance.enable }}
@@ -149,6 +152,9 @@ spec:
 {{- end }}
 {{- end }}
       volumes:
+        {{- with .Values.extraVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         - name: "certs"
           secret:
             secretName: {{ .Values.certsSecret.name }}

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -261,6 +261,12 @@ extraSecretEnvironmentVars: []
   #   secretName: name
   #   secretKey: key
 
+# extraVolumeMounts is a list of extra volumes to mount into the container's filesystem of the KubeEnforcer deployment
+extraVolumeMounts: []
+
+# extraVolumes is a list of volumes that can be mounted inside the KubeEnforcer deployment
+extraVolumes: []
+
 starboard:
   enabled: true
   replicaCount: "1"


### PR DESCRIPTION
In our Kubernetes clusters at @swisspost we have a policy which injects a default securityContext into every container to enforce all workloads to have a read-only root filesystem.

When KubeEnforcer is deployed using a read-only root filesystem, `/tmp` is also not writable which breaks the functionality of kube-hunter.