### PR TITLE
SLK-62280 - Adjust resource requests and limits for aqua-enforcer and…

### DIFF
--- a/enforcer/templates/enforcer-daemonset.yaml
+++ b/enforcer/templates/enforcer-daemonset.yaml
@@ -162,11 +162,11 @@ spec:
         {{- if and (not .Values.resources) .Values.expressMode }}
         resources:
           requests:
-            cpu: "300m"
-            memory: "500Mi"
+            cpu: "250m"
+            memory: "250Mi"
           limits:
-            cpu: "1500m"
-            memory: "1500Mi"
+            cpu: "1000m"
+            memory: "1200Mi"
         {{- else }}
         resources: {{ toYaml .Values.resources | nindent 12 }}
         {{- end }}

--- a/kube-enforcer/templates/kube-enforcer-deployment.yaml
+++ b/kube-enforcer/templates/kube-enforcer-deployment.yaml
@@ -95,11 +95,11 @@ spec:
           {{- if and (not .Values.resources) .Values.enforcer.expressMode }}
           resources:
             requests:
-              cpu: "300m"
-              memory: "250Mi"
+              cpu: "100m"
+              memory: "125Mi"
             limits:
               cpu: "1000m"
-              memory: "500Mi"
+              memory: "750Mi"
           {{- else }}
           resources: {{ toYaml .Values.resources | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
… kube-enforcer.

for Aqua enforcer CPU default should be defined for (250/1000) , memory should be defined for (250/1200)- it will cover the cases A-E of the sizing guide

for Kube enforcer CPU default should be defined for (100/1000) , memory should be defined for (125/750)- (sizing guide should be fixed as result of the performance test)