### PR TITLE
Feature/add PVC support for codesecagent

### DIFF
--- a/codesec-agent/templates/_helpers.tpl
+++ b/codesec-agent/templates/_helpers.tpl
@@ -119,3 +119,21 @@ example:
     {{- end }}
 {{- end }}
 {{- end -}}
+
+{{- define "scanPVCsize" -}}
+{{- if and (.Values.global.scanPVC) (.Values.global.scanPVC.size) -}}
+    {{ .Values.global.scanPVC.size | quote }}
+{{- else -}}
+    {{ (printf "15Gi") }}
+{{- end -}}
+{{- end -}}
+
+{{- define "scanStorageClass" -}}
+{{- if and (.Values.global.scanPVC) (.Values.global.scanPVC.storageClass) -}}
+    {{ .Values.global.scanPVC.storageClass | quote }}
+{{- else -}}
+    {{ (printf "default") }}
+{{- end -}}
+{{- end -}}
+
+

--- a/codesec-agent/templates/connect/scan-deployment.yaml
+++ b/codesec-agent/templates/connect/scan-deployment.yaml
@@ -73,13 +73,17 @@ spec:
           resources:
             {{- toYaml $v.resources | indent 12 }}
 
-          {{- if .Values.ssl.enabled }}
           volumeMounts:
+          {{- if .Values.ssl.enabled }}
             - name: ssl-secrets
               mountPath: "/home/node"
           {{- end }}
-          {{- if .Values.ssl.enabled }}
+          {{- if .Values.global.persistency }}
+            - name: scanner-cache
+              mountPath: "/tmp"
+          {{- end }}
       volumes:
+      {{- if .Values.ssl.enabled }}
         - name: ssl-secrets
           secret:
             secretName: {{ printf "%s-%s" (include "chart.fullname" . ) "secrets" }}
@@ -96,6 +100,11 @@ spec:
               - key: ssl-key
                 path: key.pem
               {{- end }}
+      {{- end }}
+      {{- if .Values.global.persistency }}
+        - name: scanner-cache
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-scanner-cache
       {{- end }}
     {{- with $v.nodeSelector }}
       nodeSelector:

--- a/codesec-agent/templates/connect/scan-pvc.yaml
+++ b/codesec-agent/templates/connect/scan-pvc.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.global.persistency }}
+{{- $name := printf "%s-%s" (include "chart.fullname" . ) "scanner" }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-scanner-cache
+  labels:
+    app.kubernetes.io/name: {{ $name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.global.scan-pvc.size | default "15Gi" | quote }}
+{{- if .Values.global.db.scan-pvc.storageClass }}
+  storageClassName: "{{ .Values.global.scan-pvc.storageClass }}"
+{{- end }}
+{{- end }}

--- a/codesec-agent/templates/connect/scan-pvc.yaml
+++ b/codesec-agent/templates/connect/scan-pvc.yaml
@@ -9,11 +9,14 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   accessModes:
+  {{- if gt (float64 (toString (.Values.scan.replicas))) 1.0 }}
     - ReadWriteMany
+  {{- else }}
+    - ReadWriteOnce
+  {{- end }}
   resources:
     requests:
-      storage: {{ .Values.global.scan-pvc.size | default "15Gi" | quote }}
-{{- if .Values.global.db.scan-pvc.storageClass }}
-  storageClassName: "{{ .Values.global.scan-pvc.storageClass }}"
+      storage: {{ template "scanPVCsize" . }}
+  storageClassName: {{ template "scanStorageClass" . }}
 {{- end }}
-{{- end }}
+

--- a/codesec-agent/values.yaml
+++ b/codesec-agent/values.yaml
@@ -3,6 +3,13 @@ global:
   scanServerUrl: https://scan.codesec.aquasec.com
   aquaServerUrl: https://api.aquasec.com
   cspmServerUrl: https://api.cloudsploit.com
+  #Please specify if you want to use PVC or not. 
+  #PVC might be need on hardened infrastructure such as Openshift, as scanner needs to writes to /tmp
+  persistency: false
+  # optional changes to pvc in case needed
+  # scan-pvc: 
+  #   size: 15Gi
+  #   storageClass: ""
 
 credentials:
   aqua_key:

--- a/codesec-agent/values.yaml
+++ b/codesec-agent/values.yaml
@@ -3,25 +3,27 @@ global:
   scanServerUrl: https://scan.codesec.aquasec.com
   aquaServerUrl: https://api.aquasec.com
   cspmServerUrl: https://api.cloudsploit.com
-  #Please specify if you want to use PVC or not. 
-  #PVC might be need on hardened infrastructure such as Openshift, as scanner needs to writes to /tmp
-  persistency: false
+  # Please specify if you want to use PVC or not. 
+  # PVC might be need on hardened infrastructure such as Openshift, as scanner needs to writes to /tmp
+  # Note: NOTE: if scan.replicas >1 && persistency: true = RWX storage required
+  persistency: true
   # optional changes to pvc in case needed
-  # scan-pvc: 
+  # scanPVC: 
   #   size: 15Gi
-  #   storageClass: ""
+  #   storageClass: "default"
 
 credentials:
-  aqua_key:
-  aqua_secret:
+# obtain credentials from Aqua UI -> CSPM -> Settings -> API Keys
+  aqua_key: 
+  aqua_secret: 
 
 # SCM configurations:
 integration:
   # Should be one of: github|gitlab_server|azure|jenkins|etc...
-  source:
-  url:
-  username:
-  password:
+  source: 
+  url: 
+  username: 
+  password: 
 
 # Optionally add ssl ca cert and client cert/key for ssl connection to the SCM/CI server:
 ssl:
@@ -61,7 +63,7 @@ connect:
 scan:
   image: docker.io/aquasec/codesec-scanner:latest
   pullPolicy: Always
-  replicas: 1
+  replicas: 1 # NOTE: if >1 && persistency: true = RWX storage required
   resources: {}
   nodeSelector: {}
   affinity: {}


### PR DESCRIPTION
Environments may have issues leveraging the codesec scanner as it, because of the scanned images being cached under /tmp location. To mitigate permission issues, persistentVolumeClaim can be used to mount a volume under /tmp. 

The changes implement such PVC as an opt-in via values.yaml <persistency> key.
In addition, the size and storageClassName can be set if needed and PVC is changed to RWX type if scan replica is greater than 1. 