### PR TITLE
feat(codesec-agent-connector): add proxy preference rule

### DIFF
--- a/codesec-agent/CHANGELOG.md
+++ b/codesec-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+_1.2.3
+* Connector now supports choosing between outbound, inbound or both for proxy preferences.
+
 _1.2.2_
 * Inject authentication (CSPM_URL) and API (AQUA_SERVER_URL) environment variables to deployment objects.
 * Fix default value of "aquaServerUrl".

--- a/codesec-agent/Chart.yaml
+++ b/codesec-agent/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: codesec-agent
 description: A Helm chart for Aqua supply chain security
-version: "1.2.2"
+version: "1.2.3"
 icon: https://avatars3.githubusercontent.com/u/12783832?s=200&v=4
 home: https://www.aquasec.com
 maintainers:
-- name: Aqua Security, Inc.
-  email: support@aquasec.com
+  - name: Aqua Security, Inc.
+    email: support@aquasec.com

--- a/codesec-agent/README.md
+++ b/codesec-agent/README.md
@@ -2,7 +2,7 @@
 
 # Aqua Security Codesec Agent Helm Chart
 
-*Protect your Software Supply Chain.*
+_Protect your Software Supply Chain._
 
 > Using this helm chart, you can integrate code security into your organization
 
@@ -17,35 +17,39 @@
     - [Mandatory Variables](#mandatory-variables)
     - [Optional Variables](#optional-variables)
 
-
-
 ## Prerequisites and limitations
 
-* The deployment requires network access to the desired integration(SCM/Artifactory/CI tools).
-* This deployment is not for Air gapped environments.
-* Access Token/App Token for the specific integration.
-* Available integrations(and how to generate access token):
-  * [Gitlab Server](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#create-a-personal-access-token)
-  * [Azure Devops Server](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows)
-  * [BitBucket Server](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html)
-  * [JFrog Server](https://www.jfrog.com/confluence/display/JFROG/Access+Tokens)
-  * Nexus
+- The deployment requires network access to the desired integration(SCM/Artifactory/CI tools).
+- This deployment is not for Air gapped environments.
+- Access Token/App Token for the specific integration.
+- Available integrations(and how to generate access token):
+  - [Gitlab Server](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#create-a-personal-access-token)
+  - [Azure Devops Server](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows)
+  - [BitBucket Server](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html)
+  - [JFrog Server](https://www.jfrog.com/confluence/display/JFROG/Access+Tokens)
+  - Nexus
 
 ## Installing the chart
 
 Follow the steps in this section for production grade deployments. You can either clone aqua-helm git repo or you can add our helm private repository (https://helm.aquasec.com)
 
 ### Installing Codesec Agents from Helm Private Repository
-* Add Aqua Helm Repository
+
+- Add Aqua Helm Repository
+
 ```bash
 helm repo add aqua-helm https://helm.aquasec.com
 helm repo update
 ```
-* Check for available chart versions by running the below command
+
+- Check for available chart versions by running the below command
+
 ```bash
 helm search repo aqua-helm/codesec-agent --versions
 ```
-* Install the Agents
+
+- Install the Agents
+
 ```bash
 helm upgrade --install --namespace aqua-codesec <RELEASE_NAME> aqua-helm/codesec-agent \
 --set credentials.aqua_key=<AQUA API KEY> \
@@ -59,46 +63,50 @@ helm upgrade --install --namespace aqua-codesec <RELEASE_NAME> aqua-helm/codesec
 ## Variables
 
 In-order to deploy successfully there are mandatory and optional variables for certain occasions:
-* Mandatory Aqua account credentials
-* Mandatory Integration credentials
-* Optional SSL credentials for Environments that are using CA and certificates
-* Optional Http/s Proxy specification
 
-___
+- Mandatory Aqua account credentials
+- Mandatory Integration credentials
+- Optional SSL credentials for Environments that are using CA and certificates
+- Optional Http/s Proxy specification with prefence for what calls to proxy "outbound" or "inbound" or "both"
+
+---
+
 ### Mandatory Variables
 
-| Variable | Type | Description | Example |
-| -------- | ----------- | -------- | ---- |
-| credentials.aqua_key | String |The Aqua account api key |
-| credentials.aqua_secret | String | The Aqua account api key secret |
-| integration.source | String(Enum) | The type of the integration (gitlab_server, azure_server, bitbucket_server,jenkins,nexus,jfrog_server) | "gitlab_server" |
-| integration.url| String | The SCM/Artifactory/CI integration endpoint | "https://my-gitlab-server.com" |
-| integration.username | String | The SCM/Artifactory/CI account username or access token name | |
-| integration.password | String | The SCM/Artifactory/CI account password or access token value | |
+| Variable                | Type         | Description                                                                                            | Example                        |
+| ----------------------- | ------------ | ------------------------------------------------------------------------------------------------------ | ------------------------------ |
+| credentials.aqua_key    | String       | The Aqua account api key                                                                               |
+| credentials.aqua_secret | String       | The Aqua account api key secret                                                                        |
+| integration.source      | String(Enum) | The type of the integration (gitlab_server, azure_server, bitbucket_server,jenkins,nexus,jfrog_server) | "gitlab_server"                |
+| integration.url         | String       | The SCM/Artifactory/CI integration endpoint                                                            | "https://my-gitlab-server.com" |
+| integration.username    | String       | The SCM/Artifactory/CI account username or access token name                                           |                                |
+| integration.password    | String       | The SCM/Artifactory/CI account password or access token value                                          |                                |
 
-___
+---
+
 ### Optional Variables
 
-| Variable                    | Type    | Description                                                   | Example                                            | Default |
-|-----------------------------|---------|---------------------------------------------------------------|----------------------------------------------------|---------|
-| ssl.enabled                 | Boolean | Enable usage of SSL Certificates                              |                                                    | false   |
-| ssl.ca                      | String  | The CA file content                                           |                                                    |         |
-| ssl.cert                    | String  | The Certificate file content                                  |                                                    |         |
-| ssl.key                     | String  | The Certificate private key                                   |                                                    |         |
-| proxy.url                   | String  | The url to the http/s proxy including any required basic auth | https://username:password@my-proxy-server.com:8080 |         |
-| connect.port                | Number  | The connector http service port                               |                                                    | 9999    |
-| connect.service.port        | Number  | The connector service port                                    |                                                    | 9999    |
-| connect.service.annotations | Object  | Any annotations for the Connector service                     |                                                    |         |
-| connect.resources           | Object  | Resource limitation for the connector deployment              |                                                    | {}      |
-| connect.nodeSelector        | Object  | Node selector configuration for the connector deployment      |                                                    | {}      |
-| connect.affinity            | Object  | Affinity configuration for the connector deployment           |                                                    | {}      |
-| connect.tolerations         | Object  | Tolerations configuration for the connector deployment        |                                                    | {}      |
-| connect.hostAliases         | Object  | Host Aliases configuration for the connector deployment       |                                                    |         |
-| connect.extraEnv            | Object  | Extra environment variables to pass to the connect container. |                                                    | {}      |
-| scan.replicas               | Number  | Number of pod replicas for the "scanner" service.             |                                                    | 1       |
-| scan.resources              | Object  | Resource limitation for the scanner deployment                |                                                    | {}      |
-| scan.nodeSelector           | Object  | Node selector configuration for the scanner deployment        |                                                    | {}      |
-| scan.affinity               | Object  | Affinity configuration for the scanner deployment             |                                                    | {}      |
-| scan.tolerations            | Object  | Tolerations configuration for the scanner deployment          |                                                    | {}      |
-| scan.hostAliases            | Object  | Host Aliases configuration for the scanner deployment         |                                                    |         |
-| scan.extraEnv               | Object  | Extra environment variables to pass to the scanner container. |                                                    | {}      |
+| Variable                    | Type    | Description                                                                         | Example                                            | Default    |
+| --------------------------- | ------- | ----------------------------------------------------------------------------------- | -------------------------------------------------- | ---------- |
+| ssl.enabled                 | Boolean | Enable usage of SSL Certificates                                                    |                                                    | false      |
+| ssl.ca                      | String  | The CA file content                                                                 |                                                    |            |
+| ssl.cert                    | String  | The Certificate file content                                                        |                                                    |            |
+| ssl.key                     | String  | The Certificate private key                                                         |                                                    |            |
+| proxy.url                   | String  | The url to the http/s proxy including any required basic auth                       | https://username:password@my-proxy-server.com:8080 |            |
+| proxy.preference            | String  | Choose between 'outbound' / 'inbound' / 'both' to apply proxy rerouting accordingly | "outbound"                                         | "outbound" |
+| connect.port                | Number  | The connector http service port                                                     |                                                    | 9999       |
+| connect.service.port        | Number  | The connector service port                                                          |                                                    | 9999       |
+| connect.service.annotations | Object  | Any annotations for the Connector service                                           |                                                    |            |
+| connect.resources           | Object  | Resource limitation for the connector deployment                                    |                                                    | {}         |
+| connect.nodeSelector        | Object  | Node selector configuration for the connector deployment                            |                                                    | {}         |
+| connect.affinity            | Object  | Affinity configuration for the connector deployment                                 |                                                    | {}         |
+| connect.tolerations         | Object  | Tolerations configuration for the connector deployment                              |                                                    | {}         |
+| connect.hostAliases         | Object  | Host Aliases configuration for the connector deployment                             |                                                    |            |
+| connect.extraEnv            | Object  | Extra environment variables to pass to the connect container.                       |                                                    | {}         |
+| scan.replicas               | Number  | Number of pod replicas for the "scanner" service.                                   |                                                    | 1          |
+| scan.resources              | Object  | Resource limitation for the scanner deployment                                      |                                                    | {}         |
+| scan.nodeSelector           | Object  | Node selector configuration for the scanner deployment                              |                                                    | {}         |
+| scan.affinity               | Object  | Affinity configuration for the scanner deployment                                   |                                                    | {}         |
+| scan.tolerations            | Object  | Tolerations configuration for the scanner deployment                                |                                                    | {}         |
+| scan.hostAliases            | Object  | Host Aliases configuration for the scanner deployment                               |                                                    |            |
+| scan.extraEnv               | Object  | Extra environment variables to pass to the scanner container.                       |                                                    | {}         |

--- a/codesec-agent/templates/connect/connect-deployment.yaml
+++ b/codesec-agent/templates/connect/connect-deployment.yaml
@@ -64,6 +64,11 @@ spec:
             value: {{ .Values.proxy.url }}
           {{- end }}
 
+          {{- if .Values.proxy.preference }}
+          - name: PROXY_PREFERENCE
+            value: {{ .Values.proxy.preference }}
+          {{- end }}
+
           {{- range $key, $value := .Values.connect.extraEnv }}
           - name: {{ $key }}
             value: "{{ $value }}"

--- a/codesec-agent/templates/validator.yaml
+++ b/codesec-agent/templates/validator.yaml
@@ -28,3 +28,9 @@
 {{- if empty .Values.integration.source }}
 {{ fail "Error - missing .Values.integration.source" }}
 {{- end }}
+{{- if .Values.proxy.url }}
+    {{- if and (ne .Values.proxy.preference "outbound") (ne .Values.proxy.preference "inbound") (ne .Values.proxy.preference "both") -}}
+        {{ fail "Error - .Values.proxy.preference should be 'outbound' or 'inbound' or 'both'" }}
+    {{- end }}
+{{- end }}
+

--- a/codesec-agent/values.yaml
+++ b/codesec-agent/values.yaml
@@ -34,6 +34,7 @@ ssl:
 
 proxy:
   url:
+  preference: outbound
 
 connect:
   image: docker.io/aquasec/codesec-connector:minified

--- a/codesec-agent/values.yaml
+++ b/codesec-agent/values.yaml
@@ -32,8 +32,18 @@ ssl:
 #    secure key
 #    -----BEGIN RSA PRIVATE KEY-----
 
+# Proxy configurations:
 proxy:
+  # The proxy url to redirect requests to.
   url:
+  # Proxy redirection preference
+  # Allowed values: inbound|outbound|both
+  # inbound: redirect only inbound requests through the proxy
+  # Description: requests to the integration only, requests to Aqua Security servers will not be proxied
+  # outbound: redirect only outbound requests through the proxy
+  # Description: requests to Aqua Security servers only, requests to the integration will not be proxied
+  # both: redirect both inbound and outbound requests through the proxy
+  # Description: requests to Aqua Security servers and requests to the integration will be proxied
   preference: outbound
 
 connect:


### PR DESCRIPTION
Following enhancement in codesec connector now you can select which requests are being proxies using environment `PROXY_PREFERENCE` that accepts the following strings `outbound` `inbound` `both` 
where `outbound` apply proxy only to outgoing calls into Aqua servers
`inbound` apply proxy only to the integration calls
`both` apply to both