### PR TITLE
add HashiCorp vault support to server -  #753

### DIFF
--- a/server/templates/db-password-secret.yaml
+++ b/server/templates/db-password-secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.vaultSecret.enabled }}
 {{- if not .Values.global.db.passwordFromSecret.enabled  }}
 {{- if .Values.global.db.external.enabled }}
 ---
@@ -40,5 +41,6 @@ type: Opaque
 data:
   db-password: {{ randAlphaNum 20 | b64enc | quote }}
   audit-password: {{ randAlphaNum 20 | b64enc | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/server/templates/web-deployment.yaml
+++ b/server/templates/web-deployment.yaml
@@ -25,6 +25,11 @@ spec:
         {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- end }}
+      {{- if .Values.vaultSecret.enabled }}
+      {{- with .Values.vaultAnnotations }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- end }}
       labels:
         app: {{ .Release.Name }}-console
         aqua.component: server
@@ -50,7 +55,12 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ .Release.Name }}-web-config
+        {{- if .Values.vaultSecret.enabled }}
+        command: ["/bin/sh"]
+        args: ["-c", "source {{ .Values.vaultSecret.vaultFilepath }} && /web-entrypoint.sh"]
+        {{- end }}
         env:
+        {{- if not .Values.vaultSecret.enabled }}
         {{- if .Values.global.db.passwordFromSecret.enabled }}
         - name: SCALOCK_DBPASSWORD
           valueFrom:
@@ -104,6 +114,7 @@ spec:
               {{- end }}
           {{- end }}
         {{- end }}
+        {{- end }}
         {{- if .Values.global.db.externalDbCerts.enable }}
         - name: SSL_CERT_DIR
           value: "/etc/ext_db_certs:/etc/ssl/certs"
@@ -115,12 +126,14 @@ spec:
               name: {{ template "admin.secretName" . }}
               key: license-token
         {{- end }}
+        {{- if not .Values.vaultSecret.enabled }}
         {{- if or .Values.admin.password (not .Values.admin.createSecret) }}
         - name: ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "admin.secretName" . }}
               key: admin-password
+        {{- end }}
         {{- end }}
         {{- include "server.extraEnvironmentVars" .Values.web | nindent 8 }}
         {{- include "server.extraSecretEnvironmentVars" .Values.web | nindent 8 }}

--- a/server/templates/web-secrets.yaml
+++ b/server/templates/web-secrets.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.vaultSecret.enabled }}
 {{- if .Values.admin.createSecret  }}
 ---
 apiVersion: v1
@@ -16,5 +17,6 @@ data:
 {{- end }}
 {{- if .Values.admin.token }}
   license-token: {{ .Values.admin.token | b64enc | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -34,6 +34,30 @@ serviceAccount:
 clustermode: ""
 activeactive: ""
 
+# Hashicorp Vault for secrets management
+# Below vaultSecret and vaultAnnotations section helps setting vault sidecar/init-container agents to load secrets securely
+vaultSecret:
+  enabled: false          # Enable to true once you have secrets in vault and annotations are enabled to load admin and db passwords from vault
+  vaultFilepath: ""       # Change the path to "/vault/secrets/<filename>" as per the setup
+
+# Add hashicorp Vault annotations to enable sidecar/init-container vault agent to load admin and db passwords
+# example annotations for self-hosted vault server:
+vaultAnnotations:
+  ####
+  # vault.hashicorp.com/agent-inject: "true"
+  # vault.hashicorp.com/agent-inject-status: update
+  # vault.hashicorp.com/agent-pre-populate-only: 'false'                 # Enable to true to add vault agent as init-container without sidecar
+  # vault.hashicorp.com/role: "aqua-enforcer"                            # Specify your role used by vault agent auto-auth
+  # vault.hashicorp.com/agent-inject-secret-enforcer-server ""           # Specify your vault secrets path, e.g. `kv/aqua-enforcer/server`
+  # vault.hashicorp.com/agent-inject-template-enforcer-server: |
+  #  {{- with secret "kv/aqua-enforcer/server" -}}            
+  #  export ADMIN_PASSWORD="{{ .Data.data.admin_password}}"              # Specify your stored vault secret keys, e.g. admin_password
+  #  export SCALOCK_DBPASSWORD="{{ .Data.data.db_password}}"
+  #  export SCALOCK_AUDIT_DBPASSWORD="{{ .Data.data.db_audit_password}}"
+  #  export AQUA_PUBSUB_DBPASSWORD="{{ .Data.data.db_pubsub_password}}"
+  #  {{- end -}}
+  ####
+
 admin:
   createSecret: true
   secretName: aqua-console-secrets


### PR DESCRIPTION
Issue: [753](https://github.com/aquasecurity/aqua-helm/issues/753)

The Aqua Enforcer and KubeEnforcer already support HashiCorp Vault Agent injection. This PR adds support to the server. 