### PR TITLE
feat(kube-enforcer): add deploymentAnnotations option to control deployment annotations

### DIFF
--- a/kube-enforcer/templates/kube-enforcer-deployment.yaml
+++ b/kube-enforcer/templates/kube-enforcer-deployment.yaml
@@ -6,6 +6,12 @@ metadata:
     app: {{ include "kube-enforcer.fullname" . }}
     aqua.component: kubeenforcer
 {{ include "aqua.labels" . | indent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- range $key,$value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
   name: {{ include "kube-enforcer.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -226,6 +226,7 @@ resources: {}
 nodeSelector: {}
 tolerations: []
 podAnnotations: {}
+deploymentAnnotations: {}
 podLabels: {}
 affinity: {}
 


### PR DESCRIPTION
this is useful for example with argo cd sync waves

Signed-off-by: Sjouke de Vries <info@sdvservices.nl>