### PR TITLE
Super Charging Persistence

### DIFF
--- a/scanner/CHANGELOG.md
+++ b/scanner/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## 2022.4.6 (Sept 6th, 2023)
+* Fix scanner persistence to allow for multiple scanners
+* Add support for custom volumes and mount points
+
 ## 2022.4.5 (Jul 19th, 2023)
 * Fix scanner persistence volume
 

--- a/scanner/Chart.yaml
+++ b/scanner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2022.4"
 description: A Helm chart for the Aqua Scanner CLI component
 name: scanner
-version: "2022.4.5"
+version: "2022.4.6"
 icon: https://avatars3.githubusercontent.com/u/12783832?s=200&v=4
 home: https://www.aquasec.com/
 maintainers:

--- a/scanner/README.md
+++ b/scanner/README.md
@@ -127,6 +127,9 @@ Parameter | Description                                                         
 `podAnnotations` | Kubernetes pod annotations                                                                                                                                  | `{}`                   | `NO`
 `extraEnvironmentVars` | is a list of extra environment variables to set in the scanner deployments.                                                                                 | `{}`                   | `NO`
 `extraSecretEnvironmentVars` | is a list of extra environment variables to set in the scanner deployments, these variables take value from existing Secret objects.                        | `[]`                   | `NO`
+`additionalVolumes` | is a list of extra volumes necessary to mount inside of the scanner container.                        | `[]`                   | `NO`
+`additionalVolumeMounts` | is a list of extra mount points for the additional volumes.                        | `[]`                   | `NO`
+
 ## Issues and feedback
 
 If you encounter any problems or would like to give us feedback on deployments, we encourage you to raise issues here on GitHub.

--- a/scanner/templates/openshift-scc.yaml
+++ b/scanner/templates/openshift-scc.yaml
@@ -35,4 +35,7 @@ volumes:
   - configMap
   - secret
   - hostPath
+  {{- if (.Values.persistence.enabled) }}
+  - persistentVolumeClaim
+  {{- end }}
 {{- end }}

--- a/scanner/templates/scanner-deployment.yaml
+++ b/scanner/templates/scanner-deployment.yaml
@@ -124,7 +124,7 @@ spec:
         {{- end }}
         {{- include "scanner.extraEnvironmentVars" .Values | nindent 8 }}
         {{- include "scanner.extraSecretEnvironmentVars" .Values | nindent 8 }}
-        {{- if or (.Values.dockerSock.mount) (.Values.serverSSL.enable) (.Values.cyberCenter.mtls.enabled) (.Values.additionalCerts) (.Values.persistence.enabled) }}
+        {{- if or (.Values.dockerSock.mount) (.Values.serverSSL.enable) (.Values.cyberCenter.mtls.enabled) (.Values.additionalCerts) (.Values.persistence.enabled) (.Values.additionalVolumeMounts) }}
         volumeMounts:
         {{- end }}
         {{- if .Values.dockerSock.mount }}
@@ -145,6 +145,9 @@ spec:
           mountPath: /opt/aquascans
         {{- end }}
         {{- include "scanner.additionalCertVolumeMounts" .Values | nindent 8 }}
+        {{- with .Values.additionalVolumeMounts }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
         ports:
         - containerPort: 8080
           protocol: TCP
@@ -170,7 +173,7 @@ spec:
       tolerations:
         {{ toYaml . | nindent 6 }}
       {{- end }}
-      {{- if or (.Values.dockerSock.mount) (.Values.serverSSL.enable) (.Values.cyberCenter.mtls.enabled) (.Values.additionalCerts) (.Values.persistence.enabled) }}
+      {{- if or (.Values.dockerSock.mount) (.Values.serverSSL.enable) (.Values.cyberCenter.mtls.enabled) (.Values.additionalCerts) (.Values.persistence.enabled) (.Values.additionalVolumes) }}
       volumes:
       {{- end }}
       {{- if .Values.dockerSock.mount }}
@@ -206,8 +209,29 @@ spec:
           {{- end }}
       {{- end }}
       {{- include "scanner.additionalCertVolumes" .Values | nindent 6 }}
-      {{- if .Values.persistence.enabled }}
-      - name: scanner-pvc
+      {{- if and (.Values.persistence.enabled) (not (and (eq .Values.persistence.accessMode "ReadWriteOnce") (gt .Values.replicaCount 1))) }}
+      - name: pvc
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-scanner-pvc
       {{- end -}}
+      {{- with .Values.additionalVolumes }}
+      {{ toYaml . | nindent 6 }}
+      {{- end }}
+  {{- if (.Values.persistence.enabled) (eq .Values.persistence.accessMode "ReadWriteOnce") (gt .Values.replicaCount 1) }}
+  volumeClaimTemplate:
+  - metadata:
+      name: pvc
+      labels:
+        app: {{ .Release.Name }}-scanner
+        aqua.component: scanner
+        {{ include "aqua.labels" . | nindent 8 }}
+    spec:
+      accessModes: 
+        - "ReadWriteOnce"
+      {{- if .Values.persistence.storageclass }}
+      storageClassName: {{ .Values.persistence.storageclass }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size_in_gb }}Gi
+  {{- end -}}

--- a/scanner/templates/scanner-pvc.yaml
+++ b/scanner/templates/scanner-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled }}
+{{- if and (.Values.persistence.enabled) (not (and (eq .Values.persistence.accessMode "ReadWriteOnce") (gt .Values.replicaCount 1))) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/scanner/values.yaml
+++ b/scanner/values.yaml
@@ -148,3 +148,9 @@ persistence:
   accessMode: ReadWriteOnce
   size: 30Gi    # Change to required size
   storageClass: # Optional
+
+# Add additional volumes
+additionalVolumes: []
+
+# Add associated mount points
+additionalVolumeMounts: []


### PR DESCRIPTION
This MR is based on the my experience of running Aqua scanners in an OpenShift environment. This is back porting the fixes we have implemented in our clusters including production clusters.

### Issues addressed

OpenShift security context doesn't allow for PVC for Aqua Scanner.

Due to having a separate PVC associated with the Statefulset with a fixed name, the current charts limits to only one scanner with persistence if your storage is only capable of ReadWriteOnce.

It isn't possible to add volumes and mount points potentially necessary for other tools to cooperate for the scanners.

### Solutions

For the first problem, adding `persistentVolumeClaim` to the `SecurityContextConstraints`.

For the last problem, 2 additional variables have been created and mapped appropriately to both `volumes` and `volumeMounts`, called `additionalVolumes` and `addtionalVolumeMounts` respectively, e.g. https://github.com/aquasecurity/aqua-helm/issues/691

For the main problem, reverted change that resulted in the removal of the `volumeMountTemplate` in the case where `accessMode` is `ReadWriteOnce` and `replicaCount` is greater than 1. Using `volumeMountTemplate` in this way creates a unique pvc per scanner, getting around the limitation of storage that can only have one pod at a time have write access.