### PR TITLE
[Enforcer] add optional pod level security context

### DIFF
--- a/enforcer/README.md
+++ b/enforcer/README.md
@@ -172,8 +172,9 @@ Parameter | Description      | Default| Mandatory
 `enforcerTokenSecretKey` | enforcer token secret key if exists   | `null` | `NO`
 `logicalName` | Specify the Logical Name the Aqua Enforcer will register under. if not specify the name will be `spec.nodeName`     | `unset`| `NO`
 `nodelName` | Specify the Node Name the Aqua Enforcer will register under. if not specify the name will be `spec.nodeName`  | `unset`| `NO`
-`securityContext.privileged` | determines if any container in a pod can enable privileged mode.    | `false`| `NO`
-`securityContext.capabilities` | Linux capabilities provide a finer grained breakdown of the privileges traditionally associated with the superuser. | `add {}` | `NO`
+`securityContext` | Set a securityContext at the pod level.                                                                   | `{}`                                    | `NO`
+`container_securityContext.privileged` | determines if any container in a pod can enable privileged mode.    | `false`| `NO`
+`container_securityContext.capabilities` | Linux capabilities provide a finer grained breakdown of the privileges traditionally associated with the superuser. | `add {}` | `NO`
 `podSecurityPolicy.create` | Enable Pod Security Policies with the required enforcer capabilities| `false`| `NO`
 `podSecurityPolicy.privileged` | Enable privileged permissions to the Enforcer| `true` if podSecurityPolicy.create is `true` | `NO`
 `global.gateway.address` | Gateway host address   | `aqua-gateway-svc`    | `YES`
@@ -233,7 +234,7 @@ Parameter | Description      | Default| Mandatory
 > Note: that `imageCredentials.create` is false and if you need to create image pull secret please update to true, set the username and password for the registry and `serviceAccount.create` is false and if you're environment is new or not having aqua-sa serviceaccount please update it to true.
 
 ## Special cases
-* For EKS cluster with the Bottlerocket OS add below section under `securityContext`
+* For EKS cluster with the Bottlerocket OS add below section under `container_securityContext`
 ```yaml
 seLinuxOptions:
   user: system_u

--- a/enforcer/templates/enforcer-daemonset.yaml
+++ b/enforcer/templates/enforcer-daemonset.yaml
@@ -21,7 +21,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/enforcer-configmap.yaml") . | sha256sum }}
-      {{- if not .Values.securityContext.privileged }}
+      {{- if not .Values.container_securityContext.privileged }}
         container.apparmor.security.beta.kubernetes.io/enforcer: unconfined
       {{- end }}
       {{- if and (.Values.tolerations) (semverCompare "<1.6-0" .Capabilities.KubeVersion.GitVersion) }}
@@ -52,6 +52,10 @@ spec:
           - name: ndots
             value: {{ .Values.dnsNdots | quote }}
       {{- end }}
+      {{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       {{- if or .Values.priorityClass.create .Values.priorityClass.name }}
       priorityClassName: {{ template "priorityClass" . }}
       {{- end }}
@@ -60,8 +64,8 @@ spec:
       - name: enforcer
         image: "{{ .Values.global.imageCredentials.repositoryUriPrefix }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
+        container_securityContext:
+          {{- toYaml .Values.container_securityContext | nindent 10 }}
         {{- if .Values.vaultSecret.enabled }}
         command: ["/bin/sh"]
         args: ["-c", "source {{ .Values.vaultSecret.vaultFilepath }} && /autorun.sh"]

--- a/enforcer/values.yaml
+++ b/enforcer/values.yaml
@@ -78,7 +78,9 @@ nameOverride:
 
 expressMode: false
 
-securityContext:
+securityContext: {}
+
+container_securityContext:
   privileged: false
   capabilities:
     add:


### PR DESCRIPTION
For project I'm working on they have a requirement that they need to set a pod level security context or the container gets blocked from starting.  We've been able to make this change and use it locally but we'd like to get in merged into the official helm chart.