### PR TITLE
[server] updates to web server deployment for extra volumes / volumemounts

### DIFF
--- a/server/templates/web-deployment.yaml
+++ b/server/templates/web-deployment.yaml
@@ -154,6 +154,9 @@ spec:
 {{ toYaml . | indent 10 }}
 {{- end }}
         volumeMounts:
+        {{- with .Values.web.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         {{- if .Values.dockerSock.mount }}
         - mountPath: /var/run/docker.sock
           name: docker-socket-mount
@@ -191,6 +194,9 @@ spec:
         {{ toYaml . | nindent 6 }}
       {{- end }}
       volumes:
+      {{- with .Values.web.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.dockerSock.mount }}
       - name: docker-socket-mount
         hostPath:

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -463,6 +463,12 @@ web:
     #   secretName: name
     #   secretKey: key
 
+  # extraVolumeMounts is a list of extra volumes to mount into the container's filesystem of the KubeEnforcer deployment
+  extraVolumeMounts: []
+
+  # extraVolumes is a list of volumes that can be mounted inside the KubeEnforcer deployment
+  extraVolumes: []
+
 envoy:
   enabled: false
   replicaCount: 1


### PR DESCRIPTION
we need to add some extra volume/volumemounts to our web server deployment.  I copied the code from kube-enforcer chart to keep naming / code across charts similar.

Please let me know if you want me to bump the chart version, or if that's done with automation when the MR is merged, or anything else that's needed

I was told to file a support ticket to https://support.aquasec.com/support/tickets/34809