### PR TITLE
add overridable image repository prefix per-component

### DIFF
--- a/enforcer/templates/enforcer-daemonset.yaml
+++ b/enforcer/templates/enforcer-daemonset.yaml
@@ -58,7 +58,13 @@ spec:
       serviceAccount: {{ template "agentServiceAccount" . }}
       containers:
       - name: enforcer
+        {{- if and .Values.enforcer.imageCredentials.repositoryUriPrefix .Values.enforcer.image.repository .Values.enforcer.image.tag }}
+        image: "{{ .Values.enforcer.imageCredentials.repositoryUriPrefix }}/{{ .Values.enforcer.image.repository }}:{{ .Values.enforcer.image.tag }}"
+        {{- else if .Values.enforcer.imageCredentials.repositoryUriPrefix }}
+        image: "{{ .Values.enforcer.imageCredentials.repositoryUriPrefix }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- else }}
         image: "{{ .Values.global.imageCredentials.repositoryUriPrefix }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- end }}
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}

--- a/enforcer/templates/enforcer-windows-daemonset.yaml
+++ b/enforcer/templates/enforcer-windows-daemonset.yaml
@@ -47,7 +47,11 @@ spec:
       serviceAccount: {{ template "agentServiceAccount" . }}
       containers:
       - name: aqua-windows-enforcer
+        {{- if .Values.windowsEnforcer.imageCredentials.repositoryUriPrefix }}
+        image: "{{ .Values.windowsEnforcer.imageCredentials.repositoryUriPrefix }}/{{ .Values.windowsEnforcer.image.repository }}:{{ .Values.windowsEnforcer.image.tag }}"
+        {{- else }}
         image: "{{ .Values.global.imageCredentials.repositoryUriPrefix }}/{{ .Values.windowsEnforcer.image.repository }}:{{ .Values.windowsEnforcer.image.tag }}"
+        {{- end }}
         imagePullPolicy: "{{ .Values.windowsEnforcer.image.pullPolicy }}"
         securityContext:
           {{- toYaml .Values.windowsEnforcer.securityContext | nindent 10 }}

--- a/kube-enforcer/templates/kube-enforcer-deployment.yaml
+++ b/kube-enforcer/templates/kube-enforcer-deployment.yaml
@@ -55,7 +55,11 @@ spec:
           securityContext:
 {{ toYaml . | indent 12 }}
           {{- end }}
+          {{- if .Values.imageCredentials.repositoryUriPrefix }}
+          image: "{{ .Values.imageCredentials.repositoryUriPrefix }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- else }}
           image: "{{ .Values.global.imageCredentials.repositoryUriPrefix }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- end }}
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           {{- if .Values.vaultSecret.enabled }}
           command: ["/bin/sh"]
@@ -123,7 +127,11 @@ spec:
 {{- end }}
 {{- if .Values.kubeEnforcerAdvance.enable }}
         - name: envoy
+          {{- if .Values.kubeEnforcerAdvance.imageCredentials.repositoryUriPrefix }}
+          image: "{{ .Values.kubeEnforcerAdvance.imageCredentials.repositoryUriPrefix }}/{{ .Values.kubeEnforcerAdvance.envoy.image.repository }}:{{ .Values.kubeEnforcerAdvance.envoy.image.tag }}"
+          {{- else }}
           image: "{{ .Values.global.imageCredentials.repositoryUriPrefix }}/{{ .Values.kubeEnforcerAdvance.envoy.image.repository }}:{{ .Values.kubeEnforcerAdvance.envoy.image.tag }}"
+          {{- end }}
           imagePullPolicy: "{{ .Values.kubeEnforcerAdvance.envoy.image.pullPolicy }}"
           command: ["/bin/sh", "-c", "cp /etc/envoy/cds.yaml /etc/aquasec/envoy/cds.yaml && touch /etc/aquasec/envoy/ca-certificates.crt && envoy -c /etc/envoy/envoy.yaml"]
           ports:


### PR DESCRIPTION
this adds individually overridable image repositories per-component, which was required recently in our use-case for a self-hosted enforcer-daemonset image,