### PR TITLE
Upgrade trivy-operator version 0.16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This repository includes the following charts; they can be deployed separately:
 | [Server](server/)                   | Deploys the Console, Database, and Gateway components; optionally deploys Envoy component                                                                     | 2022.4.19            |
 | [Enforcer](enforcer/)               | Deploys the Aqua Enforcer daemonset                                                                                                                           | 2022.4.16            |
 | [Scanner](scanner/)                 | Deploys the Aqua Scanner deployment                                                                                                                           | 2022.4.6             |
-| [KubeEnforcer](kube-enforcer/)      | Deploys Aqua KubeEnforcer                                                                                                                                     | 2022.4.31            |
+| [KubeEnforcer](kube-enforcer/)      | Deploys Aqua KubeEnforcer                                                                                                                                     | 2022.4.32            |
 | [Gateway](gateway)                  | Deploys the Aqua Standalone Gateway                                                                                                                           | 2022.4.12            |
 | [Tenant-Manager](tenant-manager/)   | Deploys the Aqua Tenant Manager                                                                                                                               | 2022.4.0             |
 | [Cyber Center](cyber-center/)       | Deploys Aqua CyberCenter offline for air-gap environment                                                                                                      | 2022.4.2             |
@@ -81,7 +81,7 @@ aqua-helm/codesec-agent         1.2.3           2022.4          A Helm chart for
 aqua-helm/cloud-connector       2022.4.4        2022.4          A Helm chart for Aqua Cloud-Connector
 aqua-helm/cyber-center          2022.4.2        2022.4          A Helm chart for Aqua CyberCenter
 aqua-helm/enforcer              2022.4.16       2022.4          A Helm chart for the Aqua Enforcer
-aqua-helm/kube-enforcer         2022.4.31       2022.4          A Helm chart for the Aqua KubeEnforcer Starboard
+aqua-helm/kube-enforcer         2022.4.32       2022.4          A Helm chart for the Aqua KubeEnforcer Starboard
 aqua-helm/gateway               2022.4.12       2022.4          A Helm chart for the Aqua Gateway
 aqua-helm/scanner               2022.4.6        2022.4          A Helm chart for the Aqua Scanner CLI component
 aqua-helm/server                2022.4.19       2022.4          A Helm chart for the Aqua Console components

--- a/kube-enforcer/CHANGELOG.md
+++ b/kube-enforcer/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 2022.4.32 ( Oct 30th, 2023 )
+* Update trivy-operator version timeoutSeconds
+
 ## 2022.4.31 ( Oct 24th, 2023 )
 * Add support for trivy resource definition SLK-74400
 * Add support for trivy images pull for private registry SLK-74401

--- a/kube-enforcer/Chart.yaml
+++ b/kube-enforcer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2022.4"
 description: A Helm chart for the Aqua KubeEnforcer
 name: kube-enforcer
-version: "2022.4.31"
+version: "2022.4.32"
 dependencies:
   - name: enforcer
     version: "2022.4.16"

--- a/kube-enforcer/templates/trivy-deployment.yaml
+++ b/kube-enforcer/templates/trivy-deployment.yaml
@@ -73,6 +73,8 @@ spec:
               value: "true"
             - name: OPERATOR_SCANNER_REPORT_TTL
               value: "24h"
+            - name: OPERATOR_SBOM_GENERATION_ENABLED
+              value: "false"
             - name: OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED
               value: "true"
             - name: OPERATOR_CLUSTER_COMPLIANCE_ENABLED

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -281,7 +281,7 @@ trivy:
   image:
     registry: "docker.io/aquasec"
     repository: "trivy-operator"
-    tag: "0.11.0"
+    tag: "0.16.1"
     pullPolicy: IfNotPresent
     # Reference the secret for private registry
     secretName: ""


### PR DESCRIPTION
Upgrading trivy-operator version as the existing version 0.11.0 has security vulnerabilities.