### PR TITLE
Allow the API version of PodDisruptionBudget to be overridden

### DIFF
--- a/server/Chart.yaml
+++ b/server/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 appVersion: "2022.4"
 description: A Helm chart for the Aqua Console components
 name: server
-version: "2022.4.20"
+version: "2022.4.21"
 dependencies:
   - name: gateway
-    version: "2022.4.13"
+    version: "2022.4.12"
     repository: "file://../gateway/"
     condition: gateway.enabled
 icon: https://avatars3.githubusercontent.com/u/12783832?s=200&v=4

--- a/server/Chart.yaml
+++ b/server/Chart.yaml
@@ -5,7 +5,7 @@ name: server
 version: "2022.4.20"
 dependencies:
   - name: gateway
-    version: "2022.4.12"
+    version: "2022.4.13"
     repository: "file://../gateway/"
     condition: gateway.enabled
 icon: https://avatars3.githubusercontent.com/u/12783832?s=200&v=4

--- a/server/README.md
+++ b/server/README.md
@@ -11,6 +11,8 @@ These are Helm charts for installation and maintenance of Aqua Container Securit
   - [Prerequisites](#prerequisites)
     - [Container Registry Credentials](#container-registry-credentials)
     - [Service Account](#service-account)
+- [Create the ServiceAccount](#create-the-serviceaccount)
+- [Patch the ServiceAccount with the pull secret](#patch-the-serviceaccount-with-the-pull-secret)
     - [PostgreSQL database](#postgresql-database)
   - [Installing the Chart](#installing-the-chart)
     - [Installing Aqua Web from Helm Private Repository](#installing-aqua-web-from-helm-private-repository)
@@ -465,6 +467,7 @@ Parameter | Description                                                         
 `web.tolerations` | 	Kubernetes node tolerations	                                                                                                                                                                      | `[]`                                         | `NO`
 `web.affinity` | 	Kubernetes node affinity                                                                                                                                                                          | `{}`                                         | `NO`
 `web.podAnnotations` | Kubernetes pod annotations                                                                                                                                                                         | `{}`                                         | `NO`
+`web.pdbApiVersion` | 	Override the API version of the PodDisruptionBudget                                                                                                                                                      | `false`                                      | `NO`
 `web.ingress.enabled` | 	If true, Ingress will be created                                                                                                                                                                  | `false`                                      | `NO`
 `web.ingress.apiVersion` | 	Override the API version of the Ingress                                                                                                                                                           | `false`                                      | `NO`
 `web.ingress.annotations` | 	Ingress annotations	                                                                                                                                                                              | `[]`                                         | `NO`

--- a/server/templates/web-pdb.yaml
+++ b/server/templates/web-pdb.yaml
@@ -1,8 +1,12 @@
 {{- if gt (.Values.web.replicaCount | default "1" | int) 1 }}
+{{- if .Values.web.pdbApiVersion -}}
+apiVersion: {{ .Values.web.pdbApiVersion }}
+{{- else -}}
 {{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 {{- end }}
 kind: PodDisruptionBudget
 metadata:

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -377,9 +377,9 @@ web:
         protocol: TCP
   ingress:
     enabled: false
-    # Allows you to specify the API version for the Ingesss
+    # Allows you to specify the API version for the Ingress
     # This is useful where .Capabilities.APIVersions.Has does not work e.g. Helm template & ArgoCD
-    # For example: or networking.k8s.io/v1 or networking.k8s.io/v1beta1
+    # For example: networking.k8s.io/v1 or networking.k8s.io/v1beta1
     apiVersion:
     externalPort:
     annotations: {}
@@ -423,6 +423,10 @@ web:
   podAnnotations: {}
   #  my-annotation-key: my value; more value
   podLabels: {}
+  # Allows you to specify the API version for the PodDisruptionBudget
+  # This is useful where .Capabilities.APIVersions.Has does not work e.g. Helm template & ArgoCD
+  # For example: policy/v1beta1 or policy/v1
+  pdbApiVersion:
 
   securityContext:
     runAsUser: 11431


### PR DESCRIPTION
When using ArgoCD to apply the helm chart to clusters > k8 1.25 the wrong PodDisruptionBudget type is being rendered `policy/v1beta1` is being used rather than `policy/v1`

This happens because under the hood ArgoCD runs helm template and applies the resulting yaml to the cluster. Currently Argo does not pass --validate when doing the helm template which means the `.Capabilities.APIVersions.has` calls don't work see https://github.com/helm/helm/issues/10760 and https://github.com/argoproj/argo-cd/issues/3640

This PR allows the APIVersion for PodDisruptionBudget to be overridden in the values