### PR TITLE
update trivy-operator version to 0.16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This repository includes the following charts; they can be deployed separately:
 | [Server](server/)                   | Deploys the Console, Database, and Gateway components; optionally deploys Envoy component                                                                     | 2022.4.22            |
 | [Enforcer](enforcer/)               | Deploys the Aqua Enforcer daemonset                                                                                                                           | 2022.4.18            |
 | [Scanner](scanner/)                 | Deploys the Aqua Scanner deployment                                                                                                                           | 2022.4.6             |
-| [KubeEnforcer](kube-enforcer/)      | Deploys Aqua KubeEnforcer                                                                                                                                     | 2022.4.35            |
+| [KubeEnforcer](kube-enforcer/)      | Deploys Aqua KubeEnforcer                                                                                                                                     | 2022.4.36            |
 | [Gateway](gateway)                  | Deploys the Aqua Standalone Gateway                                                                                                                           | 2022.4.12            |
 | [Tenant-Manager](tenant-manager/)   | Deploys the Aqua Tenant Manager                                                                                                                               | 2022.4.0             |
 | [Cyber Center](cyber-center/)       | Deploys Aqua CyberCenter offline for air-gap environment                                                                                                      | 2022.4.2             |
@@ -81,7 +81,7 @@ aqua-helm/codesec-agent         1.2.3           2022.4          A Helm chart for
 aqua-helm/cloud-connector       2022.4.4        2022.4          A Helm chart for Aqua Cloud-Connector
 aqua-helm/cyber-center          2022.4.2        2022.4          A Helm chart for Aqua CyberCenter
 aqua-helm/enforcer              2022.4.18       2022.4          A Helm chart for the Aqua Enforcer
-aqua-helm/kube-enforcer         2022.4.35       2022.4          A Helm chart for the Aqua KubeEnforcer Starboard
+aqua-helm/kube-enforcer         2022.4.36       2022.4          A Helm chart for the Aqua KubeEnforcer Starboard
 aqua-helm/gateway               2022.4.12       2022.4          A Helm chart for the Aqua Gateway
 aqua-helm/scanner               2022.4.6        2022.4          A Helm chart for the Aqua Scanner CLI component
 aqua-helm/server                2022.4.22       2022.4          A Helm chart for the Aqua Console components

--- a/kube-enforcer/CHANGELOG.md
+++ b/kube-enforcer/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 2022.4.36 ( Dec 14th, 2023 )
+* Updated trivy-operator version to v0.16.1
+
 ## 2022.4.35 ( Dec 10th, 2023 )
 ### ⚠ BREAKING CHANGES
 * SLK-68752 - Change dnsNdots to global value

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -356,7 +356,7 @@ trivy:
   image:
     registry: "docker.io/aquasec"
     repository: "trivy-operator"
-    tag: "0.11.0"
+    tag: "0.16.1"
     pullPolicy: IfNotPresent
     # Reference the secret for private registry
     secretName: ""


### PR DESCRIPTION
updated trivy-operator version to 0.16.1 to maintain uniformity with aqua-deployments manifests https://github.com/aquasecurity/deployments/blob/5719586afe916622d03441a2dd447c074f3bd38a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/003_kube_enforcer_deploy.yaml#L101