### PR TITLE
Include the sbom environment variable in the trivy-operator.yaml file within Helm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ Refer to the Aqua Enterprise product documentation for the broader context: [Kub
 This repository includes the following charts; they can be deployed separately:
 
 | Chart                               | Description                                                                                                                                                   | Latest Chart Version |
-|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------|
-| [Server](server/)                   | Deploys the Console, Database, and Gateway components; optionally deploys Envoy component                                                                     | 2022.4.23            |
-| [Enforcer](enforcer/)               | Deploys the Aqua Enforcer daemonset                                                                                                                           | 2022.4.19            |
-| [Scanner](scanner/)                 | Deploys the Aqua Scanner deployment                                                                                                                           | 2022.4.6             |
-| [KubeEnforcer](kube-enforcer/)      | Deploys Aqua KubeEnforcer                                                                                                                                     | 2022.4.37            |
-| [Gateway](gateway)                  | Deploys the Aqua Standalone Gateway                                                                                                                           | 2022.4.12            |
-| [Tenant-Manager](tenant-manager/)   | Deploys the Aqua Tenant Manager                                                                                                                               | 2022.4.0             |
-| [Cyber Center](cyber-center/)       | Deploys Aqua CyberCenter offline for air-gap environment                                                                                                      | 2022.4.2             |
-| [Cloud Connector](cloud-connector/) | Deploys the Aqua Cloud Connector                                                                                                                              | 2022.4.4             |
-| [QuickStart](aqua-quickstart/)      | Not for production use (see [below](#quick-start-deployment-not-for-production-purposes)). Deploys the Console, Database, Gateway and KubeEnforcer components | 2022.4.1             |
-| [Codesec-Agent](codesec-agent/)     | Argon Broker Deployment                                                                                                                                       | 1.2.6                |
+|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|
+| [Server](server/)                   | Deploys the Console, Database, and Gateway components; optionally deploys Envoy component                                                                     | 2022.4.23          |
+| [Enforcer](enforcer/)               | Deploys the Aqua Enforcer daemonset                                                                                                                           | 2022.4.19          |
+| [Scanner](scanner/)                 | Deploys the Aqua Scanner deployment                                                                                                                           | 2022.4.6           |
+| [KubeEnforcer](kube-enforcer/)      | Deploys Aqua KubeEnforcer                                                                                                                                     | 2022.4.38          |
+| [Gateway](gateway)                  | Deploys the Aqua Standalone Gateway                                                                                                                           | 2022.4.12          |
+| [Tenant-Manager](tenant-manager/)   | Deploys the Aqua Tenant Manager                                                                                                                               | 2022.4.0           |
+| [Cyber Center](cyber-center/)       | Deploys Aqua CyberCenter offline for air-gap environment                                                                                                      | 2022.4.2           |
+| [Cloud Connector](cloud-connector/) | Deploys the Aqua Cloud Connector                                                                                                                              | 2022.4.4           |
+| [QuickStart](aqua-quickstart/)      | Not for production use (see [below](#quick-start-deployment-not-for-production-purposes)). Deploys the Console, Database, Gateway and KubeEnforcer components | 2022.4.1           |
+| [Codesec-Agent](codesec-agent/)     | Argon Broker Deployment                                                                                                                                       | 1.2.6              |
 
 # Deployment instructions
 
@@ -81,7 +81,7 @@ aqua-helm/codesec-agent         1.2.3           2022.4          A Helm chart for
 aqua-helm/cloud-connector       2022.4.4        2022.4          A Helm chart for Aqua Cloud-Connector
 aqua-helm/cyber-center          2022.4.2        2022.4          A Helm chart for Aqua CyberCenter
 aqua-helm/enforcer              2022.4.19       2022.4          A Helm chart for the Aqua Enforcer
-aqua-helm/kube-enforcer         2022.4.37       2022.4          A Helm chart for the Aqua KubeEnforcer Starboard
+aqua-helm/kube-enforcer         2022.4.38       2022.4          A Helm chart for the Aqua KubeEnforcer Starboard
 aqua-helm/gateway               2022.4.12       2022.4          A Helm chart for the Aqua Gateway
 aqua-helm/scanner               2022.4.6        2022.4          A Helm chart for the Aqua Scanner CLI component
 aqua-helm/server                2022.4.23       2022.4          A Helm chart for the Aqua Console components

--- a/kube-enforcer/CHANGELOG.md
+++ b/kube-enforcer/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 2022.4.38 ( Jan 8th, 2024 )
+* Updated trivy-operator.yaml to include sbom env variable
+
 ## 2022.4.37 ( Jan 3rd, 2024 )
 * Updated enforcer chart version to 2022.4.19
 * Update startboard version to 0.15.19

--- a/kube-enforcer/templates/trivy-deployment.yaml
+++ b/kube-enforcer/templates/trivy-deployment.yaml
@@ -73,6 +73,8 @@ spec:
               value: "true"
             - name: OPERATOR_SCANNER_REPORT_TTL
               value: "24h"
+            - name: OPERATOR_SBOM_GENERATION_ENABLED
+              value: "false"
             - name: OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED
               value: "true"
             - name: OPERATOR_CLUSTER_COMPLIANCE_ENABLED


### PR DESCRIPTION
Included the environment variable OPERATOR_SBOM_GENERATION_ENABLED in the trivy-deployment.yaml for Helm.

This variable is used by the Trivy Operator to enable or disable the generation of SBOM (Software Bill of Materials). Setting the value to "false" resolves the errors and prevents crashes in the trivy-operator pod.