### PR TITLE
chore: Upgrade starboard and kube-bench version to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This repository includes the following charts; they can be deployed separately:
 | [Server](server/)                   | Deploys the Console, Database, and Gateway components; optionally deploys Envoy component                                                                     | 2022.4.23            |
 | [Enforcer](enforcer/)               | Deploys the Aqua Enforcer daemonset                                                                                                                           | 2022.4.20            |
 | [Scanner](scanner/)                 | Deploys the Aqua Scanner deployment                                                                                                                           | 2022.4.6             |
-| [KubeEnforcer](kube-enforcer/)      | Deploys Aqua KubeEnforcer                                                                                                                                     | 2022.4.39            |
+| [KubeEnforcer](kube-enforcer/)      | Deploys Aqua KubeEnforcer                                                                                                                                     | 2022.4.40            |
 | [Gateway](gateway)                  | Deploys the Aqua Standalone Gateway                                                                                                                           | 2022.4.12            |
 | [Tenant-Manager](tenant-manager/)   | Deploys the Aqua Tenant Manager                                                                                                                               | 2022.4.0             |
 | [Cyber Center](cyber-center/)       | Deploys Aqua CyberCenter offline for air-gap environment                                                                                                      | 2022.4.3             |
@@ -81,7 +81,7 @@ aqua-helm/codesec-agent         1.2.3           2022.4          A Helm chart for
 aqua-helm/cloud-connector       2022.4.4        2022.4          A Helm chart for Aqua Cloud-Connector
 aqua-helm/cyber-center          2022.4.3        2022.4          A Helm chart for Aqua CyberCenter
 aqua-helm/enforcer              2022.4.20       2022.4          A Helm chart for the Aqua Enforcer
-aqua-helm/kube-enforcer         2022.4.39       2022.4          A Helm chart for the Aqua KubeEnforcer Starboard
+aqua-helm/kube-enforcer         2022.4.40       2022.4          A Helm chart for the Aqua KubeEnforcer Starboard
 aqua-helm/gateway               2022.4.12       2022.4          A Helm chart for the Aqua Gateway
 aqua-helm/scanner               2022.4.6        2022.4          A Helm chart for the Aqua Scanner CLI component
 aqua-helm/server                2022.4.23       2022.4          A Helm chart for the Aqua Console components

--- a/kube-enforcer/CHANGELOG.md
+++ b/kube-enforcer/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 2022.4.40 ( Feb 9th, 2024 )
+* starboard-operator version upgrade to 0.15.20
+* kube-bench version upgrade to v0.7.1
+
 ## 2022.4.39 ( Jan 21st, 2024 )
 * Add priority class to starboard-operator
 * Updated cluster-role.yaml to include additional permissions required for running kube-bench cis benchmarks in openshift container platform

--- a/kube-enforcer/Chart.yaml
+++ b/kube-enforcer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2022.4"
 description: A Helm chart for the Aqua KubeEnforcer
 name: kube-enforcer
-version: "2022.4.39"
+version: "2022.4.40"
 dependencies:
   - name: enforcer
     version: "2022.4.20"

--- a/kube-enforcer/templates/crds/configauditreports.yaml
+++ b/kube-enforcer/templates/crds/configauditreports.yaml
@@ -6,7 +6,7 @@ metadata:
   name: configauditreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: starboard
-    app.kubernetes.io/version: "0.15.18"
+    app.kubernetes.io/version: "0.15.20"
 spec:
   group: aquasecurity.github.io
   versions:

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -85,7 +85,7 @@ microEnforcerImage:
 # KubeBench Image
 kubebenchImage:
   repository: "aquasec/kube-bench"  # Default aqua registry KubeBench repository name
-  tag: "v0.7.0"
+  tag: "v0.7.1"
 
 # Enable/Disable KB scanning on tainted nodes
 kubeBench:
@@ -302,7 +302,7 @@ starboard:
   image:
     repositoryUriPrefix: "docker.io/aquasec"
     repository: "starboard-operator"
-    tag: "0.15.19"
+    tag: "0.15.20"
     pullPolicy: Always
 
   container_securityContext:


### PR DESCRIPTION
As the current images of starboard-operator and kube-bench in deployments are having vulnerabilities, we are upgrading them to latest inorder to be fedramp compliant.