### PR TITLE
Add additional permissions required for kube-bench checks (rh 1.0) in openshift container platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This repository includes the following charts; they can be deployed separately:
 | [Server](server/)                   | Deploys the Console, Database, and Gateway components; optionally deploys Envoy component                                                                     | 2022.4.23            |
 | [Enforcer](enforcer/)               | Deploys the Aqua Enforcer daemonset                                                                                                                           | 2022.4.20            |
 | [Scanner](scanner/)                 | Deploys the Aqua Scanner deployment                                                                                                                           | 2022.4.6             |
-| [KubeEnforcer](kube-enforcer/)      | Deploys Aqua KubeEnforcer                                                                                                                                     | 2022.4.40            |
+| [KubeEnforcer](kube-enforcer/)      | Deploys Aqua KubeEnforcer                                                                                                                                     | 2022.4.41            |
 | [Gateway](gateway)                  | Deploys the Aqua Standalone Gateway                                                                                                                           | 2022.4.12            |
 | [Tenant-Manager](tenant-manager/)   | Deploys the Aqua Tenant Manager                                                                                                                               | 2022.4.0             |
 | [Cyber Center](cyber-center/)       | Deploys Aqua CyberCenter offline for air-gap environment                                                                                                      | 2022.4.3             |
@@ -81,7 +81,7 @@ aqua-helm/codesec-agent         1.2.3           2022.4          A Helm chart for
 aqua-helm/cloud-connector       2022.4.4        2022.4          A Helm chart for Aqua Cloud-Connector
 aqua-helm/cyber-center          2022.4.3        2022.4          A Helm chart for Aqua CyberCenter
 aqua-helm/enforcer              2022.4.20       2022.4          A Helm chart for the Aqua Enforcer
-aqua-helm/kube-enforcer         2022.4.40       2022.4          A Helm chart for the Aqua KubeEnforcer Starboard
+aqua-helm/kube-enforcer         2022.4.41       2022.4          A Helm chart for the Aqua KubeEnforcer Starboard
 aqua-helm/gateway               2022.4.12       2022.4          A Helm chart for the Aqua Gateway
 aqua-helm/scanner               2022.4.6        2022.4          A Helm chart for the Aqua Scanner CLI component
 aqua-helm/server                2022.4.23       2022.4          A Helm chart for the Aqua Console components

--- a/kube-enforcer/CHANGELOG.md
+++ b/kube-enforcer/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 2022.4.41 ( Feb 27th, 2024 )
+* Add additional permissions for executing ocp checks in kube-bench
+
 ## 2022.4.40 ( Feb 9th, 2024 )
 * starboard-operator version upgrade to 0.15.20
 * kube-bench version upgrade to v0.7.1

--- a/kube-enforcer/Chart.yaml
+++ b/kube-enforcer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2022.4"
 description: A Helm chart for the Aqua KubeEnforcer
 name: kube-enforcer
-version: "2022.4.40"
+version: "2022.4.41"
 dependencies:
   - name: enforcer
     version: "2022.4.20"

--- a/kube-enforcer/templates/cluster-role.yaml
+++ b/kube-enforcer/templates/cluster-role.yaml
@@ -42,6 +42,9 @@ rules:
   - apiGroups: ["machineconfiguration.openshift.io"]
     resources: ["machineconfigs", "machineconfigpools"]
     verbs: ["get", "list"]
+  - apiGroups: [ "" ]
+    resources: [ "pods/log" ]
+    verbs: [ "get" ]
   {{- end }}
   - apiGroups:
       - "*"

--- a/kube-enforcer/templates/openshift-scc.yaml
+++ b/kube-enforcer/templates/openshift-scc.yaml
@@ -1,6 +1,6 @@
 {{- if eq .Values.global.platform "openshift" }}
 allowHostDirVolumePlugin: true
-allowHostIPC: false
+allowHostIPC: true
 allowHostNetwork: true
 allowHostPID: true
 allowHostPorts: false


### PR DESCRIPTION
Added cluster-role with get permission for pods/log resource and enabled allowHostIPC property in scc, in order excute audit commands those with oc debug node/{node_name} and access the logs of debugging session.