### PR TITLE
Add support for HostNetwork:true on Kube-enforcer deployment

### DIFF
--- a/kube-enforcer/templates/kube-enforcer-deployment.yaml
+++ b/kube-enforcer/templates/kube-enforcer-deployment.yaml
@@ -35,6 +35,7 @@ spec:
         {{- end }}
 {{ include "aqua.labels" . | indent 8 }}
     spec:
+      hostNetwork: {{ .Values.hostNetwork | default false | quote }}
       {{- if .Values.global.dnsNdots }}
       dnsConfig:
         options:


### PR DESCRIPTION
In certain setups, it's not possible for the ApiServer to reach this pod if it's not running in HostNetwork mode.  This breaks the Admission Webhook functionality of the kube-enforcer.

An example setup is EKS cluster with a CNI plugin on the worker nodes:  Such CNI won't be running on the node where the ApiServer is since it's owned by AWS so it won't be able to reach the Kube-enforcer pod unless it is on the hostNetwork.