### PR TITLE
Make ImagePullSecrets optional for Starboard SA

### DIFF
--- a/kube-enforcer/templates/service-account.yaml
+++ b/kube-enforcer/templates/service-account.yaml
@@ -30,7 +30,9 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   namespace: {{ .Release.Namespace }}
+{{- if .Values.serviceAccount.attachImagePullSecret }}
 imagePullSecrets:
 - name: {{ template "registrySecret" . }}
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This uses the same check that is done for creation of the kube-enforcer service account