### PR TITLE
Fix credential validation check for codesec-agent

### DIFF
--- a/codesec-agent/templates/validator.yaml
+++ b/codesec-agent/templates/validator.yaml
@@ -10,22 +10,22 @@
 {{- if empty .Values.global.cspmServerUrl }}
 {{ fail "Error - missing .Values.global.cspmServerUrl" }}
 {{- end }}
-{{- if .Values.credentials.createSecret  }}
+{{- if .Values.credentials.createSecret }}
 {{- if empty .Values.credentials.aqua_key }}
 {{ fail "Error - missing .Values.credentials.aqua_key" }}
 {{- end }}
-{{- if  empty .Values.credentials.aqua_secret}}
+{{- if  empty .Values.credentials.aqua_secret }}
 {{ fail "Error - missing .Values.credentials.aqua_secret" }}
-{{- end }}
-{{- end }}
-{{- if empty .Values.integration.url }}
-{{ fail "Error - missing .Values.integration.url" }}
 {{- end }}
 {{- if empty .Values.integration.username }}
 {{ fail "Error - missing .Values.integration.username" }}
 {{- end }}
 {{- if empty .Values.integration.password }}
 {{ fail "Error - missing .Values.integration.password" }}
+{{- end }}
+{{- end }}
+{{- if empty .Values.integration.url }}
+{{ fail "Error - missing .Values.integration.url" }}
 {{- end }}
 {{- if empty .Values.integration.source }}
 {{ fail "Error - missing .Values.integration.source" }}


### PR DESCRIPTION
This groups all of the validations for connection credentials inside the createSecret conditional so users don't have to supply dummy values for integration.username and integration.password.
