### PR TITLE
codesec-agent deployment annotations

### DIFF
--- a/codesec-agent/templates/connect/bleedsecrets-deployment.yaml
+++ b/codesec-agent/templates/connect/bleedsecrets-deployment.yaml
@@ -8,6 +8,13 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ $name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- $annotations := .Values.bleedsecrets.deploymentAnnotations | default dict }}
+  {{- if $annotations }}
+  annotations:
+    {{- range $key,$value := $annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   replicas: {{ .Values.bleedsecrets.replicas }}
   selector:

--- a/codesec-agent/templates/connect/connect-deployment.yaml
+++ b/codesec-agent/templates/connect/connect-deployment.yaml
@@ -7,6 +7,13 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ $name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- $annotations := .Values.connect.deploymentAnnotations | default dict }}
+  {{- if $annotations }}
+  annotations:
+    {{- range $key,$value := $annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   replicas: 1
   selector:

--- a/codesec-agent/templates/connect/remediation-deployment.yaml
+++ b/codesec-agent/templates/connect/remediation-deployment.yaml
@@ -8,6 +8,13 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ $name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- $annotations := .Values.remediation.deploymentAnnotations | default dict }}
+  {{- if $annotations }}
+  annotations:
+    {{- range $key,$value := $annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   replicas: {{ .Values.remediation.replicas }}
   selector:

--- a/codesec-agent/templates/connect/scan-deployment.yaml
+++ b/codesec-agent/templates/connect/scan-deployment.yaml
@@ -7,6 +7,13 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ $name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- $annotations := .Values.scan.deploymentAnnotations | default dict }}
+  {{- if $annotations }}
+  annotations:
+    {{- range $key,$value := $annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   replicas: {{ .Values.scan.replicas }}
   selector:

--- a/codesec-agent/values.yaml
+++ b/codesec-agent/values.yaml
@@ -70,6 +70,7 @@ connect:
     port: 9999
     type: ClusterIP
     annotations: {}
+  deploymentAnnotations: {}
   resources: {}
   nodeSelector: {}
   affinity: {}
@@ -81,6 +82,7 @@ scan:
   image: docker.io/aquasec/codesec-scanner:latest
   pullPolicy: Always
   replicas: 1
+  deploymentAnnotations: {}
   resources: {}
   nodeSelector: {}
   affinity: {}
@@ -93,6 +95,7 @@ remediation:
   image: docker.io/aquasec/codesec-remediation:latest
   pullPolicy: Always
   replicas: 1
+  deploymentAnnotations: {}
   resources: {}
   nodeSelector: {}
   affinity: {}
@@ -105,6 +108,7 @@ bleedsecrets:
   image: docker.io/aquasec/codesec-bleed-secrets:latest
   pullPolicy: Always
   replicas: 1
+  deploymentAnnotations: {}
   resources: {}
   nodeSelector: {}
   affinity: {}


### PR DESCRIPTION
This allows users to add their own annotations to deployments.
This is useful in cases where people are using deployment management tools whose roles rely on annotations to grant permissions.
