### PR TITLE
SLK-88616 - Allow user to specify where aquasec from the container will be mounted

### DIFF
--- a/enforcer/README.md
+++ b/enforcer/README.md
@@ -200,6 +200,7 @@ Parameter | Description      | Default| Mandatory
 `TLS.privateKey_fileName`   | filename of the private key eg: aqua_enforcer.key  | `nil`  |  `YES` <br /> `if TLS.enabled is set to true`
 `TLS.rootCA_fileName` | filename of the rootCA, if using self-signed certificates eg: rootCA.crt  | `nil`  |  `NO` <br /> `if TLS.enabled is set to true and using self-signed certificates for TLS/mTLS`
 `TLS.aqua_verify_enforcer` | change it to "1" or "0" for enabling/disabling mTLS between enforcer and ay/envoy        | `0`    |  `YES` <br /> `if TLS.enabled is set to true`
+`hostAquasecPath` | folder on host machine where aquasec folder in the container will be mounted | `unset` | `NO`
 `extraEnvironmentVars` | is a list of extra environment variables to set in the enforcer daemonset.| `{}`   | `NO`
 `extraSecretEnvironmentVars` | is a list of extra environment variables to set in the scanner daemonset, these variables take value from existing Secret objects. | `[]`   | `NO`
 `windowsEnforcer.allWinNodes.enable` | Enable to true, If All the nodes are windows os and it deploys only windows agents on all windows nodes | `false` | `NO`

--- a/enforcer/templates/_helpers.tpl
+++ b/enforcer/templates/_helpers.tpl
@@ -160,3 +160,10 @@ For gke-autopilot should be /var/autopilot/addon
 {{- printf "%s" "/var/lib" -}}
 {{- end -}}
 {{- end -}}
+{{- define "hostAquasecPath" -}}
+{{- if .Values.hostAquasecPath -}}
+{{- printf "%s" .Values.hostAquasecPath }}
+{{- else -}}
+{{- template "varLibPrefix" . }}/aquasec
+{{- end -}}
+{{- end -}}

--- a/enforcer/templates/enforcer-daemonset.yaml
+++ b/enforcer/templates/enforcer-daemonset.yaml
@@ -150,7 +150,7 @@ spec:
           name: aquasec-audit
         - mountPath: /data
           name: aquasec-data
-        - mountPath: {{ template "varLibPrefix" . }}/containers
+        - mountPath: /var/lib/containers
           name: containers
         {{- if .Values.healthMonitor.enabled }}
         {{- with .Values.livenessProbe }}
@@ -220,18 +220,18 @@ spec:
           type: ""
       - name: aquasec
         hostPath:
-          path: {{ template "varLibPrefix" . }}/aquasec
+          path: {{ template "hostAquasecPath" . }}
           type: ""
       - name: aquasec-tmp
         hostPath:
-          path: {{ template "varLibPrefix" . }}/aquasec/tmp
+          path: {{ template "hostAquasecPath" . }}/tmp
           type: ""
       - name: aquasec-audit
         hostPath:
-          path: {{ template "varLibPrefix" . }}/aquasec/audit
+          path: {{ template "hostAquasecPath" . }}/audit
       - name: aquasec-data
         hostPath:
-          path: {{ template "varLibPrefix" . }}/aquasec/data
+          path: {{ template "hostAquasecPath" . }}/data
           type: ""
       - name: containers
         hostPath:


### PR DESCRIPTION
The customer is unable to relocate Aqua Enforcer data from /var/lib/aquasec to /opt/aquasec, which is causing significant disk space usage issues on /var/lib.