### PR TITLE
add pull secret for private registry for starboard operator

### DIFF
--- a/kube-enforcer/templates/starboard-deployment.yaml
+++ b/kube-enforcer/templates/starboard-deployment.yaml
@@ -43,6 +43,10 @@ spec:
       {{- end }}
       serviceAccountName: {{ template "serviceAccountStarboard" . }}
       automountServiceAccountToken: {{ .Values.starboard.automountServiceAccountToken }}
+      {{- if ne .Values.starboard.image.secretName "" }}
+      imagePullSecrets:
+        - name: {{ .Values.starboard.image.secretName }}
+      {{- end }}
       {{- with .Values.starboard.securityContext }}
       securityContext:
 {{ toYaml . | indent 8 }}

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -324,6 +324,8 @@ starboard:
     repository: "starboard-operator"
     tag: "0.15.23"
     pullPolicy: Always
+    # Reference the secret for private registry
+    secretName: ""
 
   container_securityContext:
     privileged: false


### PR DESCRIPTION
in the kube-enforcer chart there is a secret reference for a private registry for trivy operator but not for starboard operator; this has been added to values.yaml and templates/starboard-deployment.yaml and tested successfully.