### PR TITLE
Removed componentstatuses permission due to deprecation

### DIFF
--- a/kube-enforcer/CHANGELOG.md
+++ b/kube-enforcer/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## 2022.4.51 ( Feb 19th, 2025 )
 * upgraded kube-bench version to v0.10.2
+* Removed ```componentstatuses``` from cluster-role_YAML as it the API is depricated
 
 ## 2022.4.50 ( Jan 1st, 2025 )
 * upgraded kube-bench version to v0.10.0

--- a/kube-enforcer/templates/cluster-role.yaml
+++ b/kube-enforcer/templates/cluster-role.yaml
@@ -9,7 +9,7 @@ metadata:
 {{ include "aqua.labels" . | indent 4 }}
 rules:
   - apiGroups: ["*"]
-    resources: ["pods", "nodes", "namespaces", "deployments", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "statefulsets", "clusterroles", "clusterrolebindings", "componentstatuses", "services" ]
+    resources: ["pods", "nodes", "namespaces", "deployments", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "statefulsets", "clusterroles", "clusterrolebindings", "services" ] #"componentstatuses" has been removed from the permissions as it is depricated.
     verbs: ["get", "list", "watch"]
   - apiGroups: ["aquasecurity.github.io"]
     resources: ["configauditreports", "clusterconfigauditreports"]


### PR DESCRIPTION
similar one raised for kube-enforcer manifest files -> https://github.com/aquasecurity/deployments/pull/592

**Deprecation of ```componentstatuses``` API and Removal from ClusterRole**

The ``componentstatuses```  API has been deprecated since **Kubernetes v1.19+**, causing frequent warnings and generating excessive log noise for customers on the latest versions.

To address this issue, we have **removed** ```componentstatuses``` from the ```ClusterRole``` YAML (001_kube_enforcer_config.yaml).

Upon reviewing the code, this API was only used to check the health status of core control plane components like **kube-scheduler, kube-controller-manager, and etcd**. The implementation simply verifies the required permissions, and if missing, logs a warning. However, in AKS clusters, customers have been repeatedly receiving deprecated API call warnings in their cluster logs.

Reference:

Support Case: #48261
Screenshot:

![image](https://github.com/user-attachments/assets/c4b7c989-dcf6-413d-80ad-5f32fd546f43)
