### PR TITLE
(Fixes #937) feat(db): Add dynamic /dev/shm sizing based on env_size

### DIFF
--- a/server/templates/_helpers.tpl
+++ b/server/templates/_helpers.tpl
@@ -144,4 +144,15 @@ Create web secret.
 {{- end -}}
 {{- end -}}
 
+{{/*
+Return the shared memory size for the Aqua DB container
+based on env_size, unless explicitly overridden via shmSize
+*/}}
+{{- define "aqua.db.shmSize" -}}
+{{- $defaultShm := dict "S" "64Mi" "M" "128Mi" "L" "256Mi" }}
+{{- $envSize := .Values.global.db.env_size | default "S" }}
+{{- $shmSize := .Values.global.db.shmSize | default (index $defaultShm $envSize) }}
+{{- $shmSize | quote }}
+{{- end }}
+
 

--- a/server/templates/db-deployment.yaml
+++ b/server/templates/db-deployment.yaml
@@ -106,6 +106,8 @@ spec:
         {{- if .Values.global.db.persistence.database.enabled }}
         - mountPath: /var/lib/postgresql/data
           name: postgres-database
+        - mountPath: /dev/shm
+          name: dshm
         {{- end }}
         ports:
         - containerPort: 5432
@@ -137,6 +139,10 @@ spec:
       - name: postgres-database
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-database-pvc
+      - name: dshm
+        emptyDir:
+          medium: Memory
+          sizeLimit: {{ include "aqua.db.shmSize" . }}
       {{- end }}
 ---
 apiVersion: apps/v1
@@ -245,6 +251,8 @@ spec:
         {{- if .Values.global.db.persistence.audit_database.enabled }}
         - mountPath: /var/lib/postgresql/data
           name: postgres-audit-database
+        - mountPath: /dev/shm
+          name: dshm
         {{- end }}
         ports:
         - containerPort: 5432
@@ -276,5 +284,9 @@ spec:
       - name: postgres-audit-database
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-audit-database-pvc
+      - name: dshm
+        emptyDir:
+          medium: Memory
+          sizeLimit: {{ include "aqua.db.shmSize" . }}
       {{- end }}
 {{- end }}

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -148,6 +148,7 @@ global:
       privileged: false
     # Possible values: “S” (default), “M”, “L”
     env_size: "S"
+    shmSize: ""        #optional override for /dev/shm size (e.g. "512Mi")
     image:
       repository: database
       tag: "2022.4"


### PR DESCRIPTION
**Motivation**
When deploying Aqua with env_size: M or L, PostgreSQL may encounter shared memory resize errors:

`could not resize shared memory segment "/PostgreSQL.xxxxx": No space left on device`

This happens because Kubernetes’ default /dev/shm size (64Mi) is insufficient for larger database memory tuning profiles (AQUA_ENV_SIZE).

**Changes Introduced**
Added global.db.shmSize value to Helm chart for /dev/shm configuration.

Implemented aqua.db.shmSize Helm helper to dynamically size /dev/shm based on env_size.

Mounted emptyDir.medium: Memory volume at /dev/shm for both database and audit database pods.

Default mapping:

S: 64Mi

M: 128Mi

L: 256Mi

Allow users to override manually with global.db.shmSize.

**Testing Performed**
Deployed Aqua using Helm with:

env_size: S → observed 64Mi /dev/shm

env_size: M → observed 128Mi /dev/shm

env_size: L → observed 256Mi /dev/shm

Manual override shmSize: "512Mi" → observed 512Mi /dev/shm

**Related Issue**
Fixes #937 

