### PR TITLE
Update values.yaml

### DIFF
--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -184,7 +184,8 @@ webhooks:
     #        - kube-system
     #        - kube-node-lease
   mutatingWebhook:
-    enabled: true
+    #enable when planning to deploy the PodEnforcer
+    enabled: false
     name: "kube-enforcer-me-injection-hook-config"
     timeout: 2
     annotations: {}


### PR DESCRIPTION
mutating webhook adds overhead and is only used in a subset of environment types. Setting this to disabled is a better standard and reduces permissions.