### PR TITLE
chore: bump Trivy Operator version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This repository includes the following charts; they can be deployed separately:
 | [Server](server/)                   | Deploys the Console, Database, and Gateway components; optionally deploys Envoy component                                                                     | 2022.4.34            |
 | [Enforcer](enforcer/)               | Deploys the Aqua Enforcer daemonset                                                                                                                           | 2022.4.25            |
 | [Scanner](scanner/)                 | Deploys the Aqua Scanner deployment                                                                                                                           | 2022.4.13            |
-| [KubeEnforcer](kube-enforcer/)      | Deploys Aqua KubeEnforcer                                                                                                                                     | 2022.4.66            |
+| [KubeEnforcer](kube-enforcer/)      | Deploys Aqua KubeEnforcer                                                                                                                                     | 2022.4.67            |
 | [Gateway](gateway)                  | Deploys the Aqua Standalone Gateway                                                                                                                           | 2022.4.17            |
 | [Tenant-Manager](tenant-manager/)   | Deploys the Aqua Tenant Manager                                                                                                                               | 2022.4.1             |
 | [Cyber Center](cyber-center/)       | Deploys Aqua CyberCenter offline for air-gap environment                                                                                                      | 2022.4.6             |
@@ -82,7 +82,7 @@ aqua-helm/codesec-agent         1.2.11          2022.4          A Helm chart for
 aqua-helm/cloud-connector       2022.4.4        2022.4          A Helm chart for Aqua Cloud-Connector
 aqua-helm/cyber-center          2022.4.6        2022.4          A Helm chart for Aqua CyberCenter
 aqua-helm/enforcer              2022.4.25       2022.4          A Helm chart for the Aqua Enforcer
-aqua-helm/kube-enforcer         2022.4.66       2022.4          A Helm chart for the Aqua KubeEnforcer Starboard/Trivy
+aqua-helm/kube-enforcer         2022.4.67       2022.4          A Helm chart for the Aqua KubeEnforcer Starboard/Trivy
 aqua-helm/gateway               2022.4.17       2022.4          A Helm chart for the Aqua Gateway
 aqua-helm/scanner               2022.4.13       2022.4          A Helm chart for the Aqua Scanner CLI component
 aqua-helm/server                2022.4.34       2022.4          A Helm chart for the Aqua Console components

--- a/kube-enforcer/CHANGELOG.md
+++ b/kube-enforcer/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 2022.4.67 ( Sep 15th, 2025 )
+* upgraded trivy-operator version to 0.28.0
+
 ## 2022.4.66 ( Sep 9th, 2025 )
 * upgraded starboard version to 0.15.27
 

--- a/kube-enforcer/Chart.yaml
+++ b/kube-enforcer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2022.4"
 description: A Helm chart for the Aqua KubeEnforcer
 name: kube-enforcer
-version: "2022.4.66"
+version: "2022.4.67"
 dependencies:
   - name: enforcer
     version: "2022.4.25"

--- a/kube-enforcer/templates/trivy-configmap.yaml
+++ b/kube-enforcer/templates/trivy-configmap.yaml
@@ -29,7 +29,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 data:
   trivy.repository: "ghcr.io/aquasecurity/trivy"
-  trivy.tag: "0.61.0"
+  trivy.tag: "0.64.1"
   trivy.additionalVulnerabilityReportFields: ""
   trivy.severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
   trivy.slow: "true"

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -396,7 +396,7 @@ trivy:
   image:
     registry: "docker.io/aquasec"
     repository: "trivy-operator"
-    tag: "0.25.0"
+    tag: "0.28.0"
     pullPolicy: IfNotPresent
     # Reference the secret for private registry
     secretName: ""


### PR DESCRIPTION
Bumped TO to the latest version (0.28.0)