### PR TITLE
feat(slk-107504): security context support

### DIFF
--- a/codesec-agent/templates/connect/bleedsecrets-deployment.yaml
+++ b/codesec-agent/templates/connect/bleedsecrets-deployment.yaml
@@ -21,6 +21,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
 {{ include "common.podLabels" . | indent 8 }}
     spec:
+      {{- with .Values.bleedsecrets.securityContext.pod }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.connect.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}
@@ -29,6 +33,10 @@ spec:
         - name: {{ $name }}
           image: {{ $v.image }}
           imagePullPolicy: {{ $v.pullPolicy }}
+          {{- with .Values.bleedsecrets.securityContext.container }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
           - name: SCANNER_SERVER
             value: {{ .Values.global.scanServerUrl }}
@@ -102,13 +110,22 @@ spec:
           resources:
             {{- toYaml $v.resources | nindent 12 }}
 
-          {{- if or .Values.ssl.enabled (and .Values.github .Values.github.cert) }}
+          {{- if or (or .Values.ssl.enabled (and .Values.github .Values.github.cert)) .Values.bleedsecrets.writableDirs }}
           volumeMounts:
+            {{- if or .Values.ssl.enabled (and .Values.github .Values.github.cert) }}
             - name: ssl-secrets
               mountPath: "/home/node"
+            {{- end }}
+            {{- if .Values.bleedsecrets.writableDirs }}
+            {{- range .Values.bleedsecrets.writableDirs }}
+            - name: writable-{{ . | replace "/" "-" | replace "_" "-" | trimPrefix "-" }}
+              mountPath: {{ . }}
+            {{- end }}
+            {{- end }}
           {{- end }}
-          {{- if or .Values.ssl.enabled (and .Values.github .Values.github.cert) }}
+          {{- if or (or .Values.ssl.enabled (and .Values.github .Values.github.cert)) .Values.bleedsecrets.writableDirs }}
       volumes:
+            {{- if or .Values.ssl.enabled (and .Values.github .Values.github.cert) }}
         - name: ssl-secrets
           secret:
             secretName: {{ template "secretName" . }}
@@ -129,6 +146,13 @@ spec:
               - key: github-certificate
                 path: github-app.pem
               {{- end }}
+            {{- end }}
+            {{- if .Values.bleedsecrets.writableDirs }}
+            {{- range .Values.bleedsecrets.writableDirs }}
+        - name: writable-{{ . | replace "/" "-" | replace "_" "-" | trimPrefix "-" }}
+          emptyDir: {}
+            {{- end }}
+            {{- end }}
       {{- end }}
     {{- with $v.nodeSelector }}
       nodeSelector:

--- a/codesec-agent/templates/connect/connect-deployment.yaml
+++ b/codesec-agent/templates/connect/connect-deployment.yaml
@@ -24,6 +24,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
 {{ include "common.podLabels" . | indent 8 }}
     spec:
+      {{- with .Values.connect.securityContext.pod }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.connect.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}
@@ -32,6 +36,10 @@ spec:
         - name: {{ $name }}
           image: {{ $v.image }}
           imagePullPolicy: {{ $v.pullPolicy | default "Always" }}
+          {{- with .Values.connect.securityContext.container }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
           - name: SERVER_URL
             value: {{ .Values.global.connectServerUrl }}
@@ -108,13 +116,22 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml $v.resources | nindent 12 }}
-          {{- if or .Values.ssl.enabled (and .Values.github .Values.github.cert) }}
+          {{- if or (or .Values.ssl.enabled (and .Values.github .Values.github.cert)) .Values.connect.writableDirs }}
           volumeMounts:
+            {{- if or .Values.ssl.enabled (and .Values.github .Values.github.cert) }}
             - name: ssl-secrets
               mountPath: "/home/node"
+            {{- end }}
+            {{- if .Values.connect.writableDirs }}
+            {{- range .Values.connect.writableDirs }}
+            - name: writable-{{ . | replace "/" "-" | replace "_" "-" | trimPrefix "-" }}
+              mountPath: {{ . }}
+            {{- end }}
+            {{- end }}
           {{- end }}
-      {{- if or .Values.ssl.enabled (and .Values.github .Values.github.cert) }}
+          {{- if or (or .Values.ssl.enabled (and .Values.github .Values.github.cert)) .Values.connect.writableDirs }}
       volumes:
+            {{- if or .Values.ssl.enabled (and .Values.github .Values.github.cert) }}
         - name: ssl-secrets
           secret:
             secretName: {{ template "secretName" . }}
@@ -135,6 +152,13 @@ spec:
               - key: github-certificate
                 path: github-app.pem
               {{- end }}
+            {{- end }}
+            {{- if .Values.connect.writableDirs }}
+            {{- range .Values.connect.writableDirs }}
+        - name: writable-{{ . | replace "/" "-" | replace "_" "-" | trimPrefix "-" }}
+          emptyDir: {}
+            {{- end }}
+            {{- end }}
       {{- end }}
     {{- with $v.nodeSelector }}
       nodeSelector:

--- a/codesec-agent/templates/connect/remediation-deployment.yaml
+++ b/codesec-agent/templates/connect/remediation-deployment.yaml
@@ -21,6 +21,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
 {{ include "common.podLabels" . | indent 8 }}
     spec:
+      {{- with .Values.remediation.securityContext.pod }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.connect.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}
@@ -29,6 +33,10 @@ spec:
         - name: {{ $name }}
           image: {{ $v.image }}
           imagePullPolicy: {{ $v.pullPolicy }}
+          {{- with .Values.remediation.securityContext.container }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
           - name: SCANNER_SERVER
             value: {{ .Values.global.scanServerUrl }}
@@ -102,13 +110,22 @@ spec:
           resources:
             {{- toYaml $v.resources | nindent 12 }}
 
-          {{- if or .Values.ssl.enabled (and .Values.github .Values.github.cert) }}
+          {{- if or (or .Values.ssl.enabled (and .Values.github .Values.github.cert)) .Values.remediation.writableDirs }}
           volumeMounts:
+            {{- if or .Values.ssl.enabled (and .Values.github .Values.github.cert) }}
             - name: ssl-secrets
               mountPath: "/home/node"
+            {{- end }}
+            {{- if .Values.remediation.writableDirs }}
+            {{- range .Values.remediation.writableDirs }}
+            - name: writable-{{ . | replace "/" "-" | replace "_" "-" | trimPrefix "-" }}
+              mountPath: {{ . }}
+            {{- end }}
+            {{- end }}
           {{- end }}
-          {{- if or .Values.ssl.enabled (and .Values.github .Values.github.cert) }}
+          {{- if or (or .Values.ssl.enabled (and .Values.github .Values.github.cert)) .Values.remediation.writableDirs }}
       volumes:
+            {{- if or .Values.ssl.enabled (and .Values.github .Values.github.cert) }}
         - name: ssl-secrets
           secret:
             secretName: {{ template "secretName" . }}
@@ -129,6 +146,13 @@ spec:
               - key: github-certificate
                 path: github-app.pem
               {{- end }}
+            {{- end }}
+            {{- if .Values.remediation.writableDirs }}
+            {{- range .Values.remediation.writableDirs }}
+        - name: writable-{{ . | replace "/" "-" | replace "_" "-" | trimPrefix "-" }}
+          emptyDir: {}
+            {{- end }}
+            {{- end }}
       {{- end }}
     {{- with $v.nodeSelector }}
       nodeSelector:

--- a/codesec-agent/templates/connect/scan-deployment.yaml
+++ b/codesec-agent/templates/connect/scan-deployment.yaml
@@ -20,6 +20,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
 {{ include "common.podLabels" . | indent 8 }}
     spec:
+      {{- with .Values.scan.securityContext.pod }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.connect.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}
@@ -28,6 +32,10 @@ spec:
         - name: {{ $name }}
           image: {{ $v.image }}
           imagePullPolicy: {{ $v.pullPolicy }}
+          {{- with .Values.scan.securityContext.container }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
           - name: SCANNER_SERVER
             value: {{ .Values.global.scanServerUrl }}
@@ -102,13 +110,22 @@ spec:
           resources:
             {{- toYaml $v.resources | nindent 12 }}
 
-          {{- if or .Values.ssl.enabled (and .Values.github .Values.github.cert) }}
+          {{- if or (or .Values.ssl.enabled (and .Values.github .Values.github.cert)) .Values.scan.writableDirs }}
           volumeMounts:
+            {{- if or .Values.ssl.enabled (and .Values.github .Values.github.cert) }}
             - name: ssl-secrets
               mountPath: "/home/node"
+            {{- end }}
+            {{- if .Values.scan.writableDirs }}
+            {{- range .Values.scan.writableDirs }}
+            - name: writable-{{ . | replace "/" "-" | replace "_" "-" | trimPrefix "-" }}
+              mountPath: {{ . }}
+            {{- end }}
+            {{- end }}
           {{- end }}
-          {{- if or .Values.ssl.enabled (and .Values.github .Values.github.cert) }}
+          {{- if or (or .Values.ssl.enabled (and .Values.github .Values.github.cert)) .Values.scan.writableDirs }}
       volumes:
+            {{- if or .Values.ssl.enabled (and .Values.github .Values.github.cert) }}
         - name: ssl-secrets
           secret:
             secretName: {{ template "secretName" . }}
@@ -129,6 +146,13 @@ spec:
               - key: github-certificate
                 path: github-app.pem
               {{- end }}
+            {{- end }}
+            {{- if .Values.scan.writableDirs }}
+            {{- range .Values.scan.writableDirs }}
+        - name: writable-{{ . | replace "/" "-" | replace "_" "-" | trimPrefix "-" }}
+          emptyDir: {}
+            {{- end }}
+            {{- end }}
       {{- end }}
     {{- with $v.nodeSelector }}
       nodeSelector:

--- a/codesec-agent/values.yaml
+++ b/codesec-agent/values.yaml
@@ -103,6 +103,30 @@ connect:
   tolerations: {}
   hostAliases:
   extraEnv: {}
+  # Writable directories (required when readOnlyRootFilesystem: true)
+  # Add directories that need to be writable, e.g., ["/tmp", "/var/tmp"]
+  writableDirs: []
+  # Security context configuration
+  # WARNING: These settings may impact functionality. Test thoroughly before enabling.
+  securityContext:
+    # Pod-level security context
+    pod:
+      # runAsNonRoot: true
+      # runAsUser: 1000
+      # runAsGroup: 1000
+      # fsGroup: 1000
+      # seccompProfile:
+      #   type: RuntimeDefault
+    # Container-level security context
+    container:
+      # allowPrivilegeEscalation: false
+      # readOnlyRootFilesystem: false
+      # runAsNonRoot: true
+      # runAsUser: 1000
+      # capabilities:
+      #   drop:
+      #     - ALL
+      #   add: []  # Add only required capabilities if needed
 
 scan:
   image: docker.io/aquasec/codesec-scanner:latest
@@ -114,6 +138,30 @@ scan:
   tolerations: {}
   hostAliases:
   extraEnv: {}
+  # Writable directories (required when readOnlyRootFilesystem: true)
+  # Add directories that need to be writable, e.g., ["/tmp", "/var/tmp"]
+  writableDirs: []
+  # Security context configuration
+  # WARNING: These settings may impact functionality. Test thoroughly before enabling.
+  securityContext:
+    # Pod-level security context
+    pod:
+      # runAsNonRoot: true
+      # runAsUser: 1000
+      # runAsGroup: 1000
+      # fsGroup: 1000
+      # seccompProfile:
+      #   type: RuntimeDefault
+    # Container-level security context
+    container:
+      # allowPrivilegeEscalation: false
+      # readOnlyRootFilesystem: false
+      # runAsNonRoot: true
+      # runAsUser: 1000
+      # capabilities:
+      #   drop:
+      #     - ALL
+      #   add: []  # Add only required capabilities if needed
 
 remediation:
   enabled: true
@@ -126,6 +174,31 @@ remediation:
   tolerations: {}
   hostAliases:
   extraEnv: {}
+  # Writable volume mounts (required when readOnlyRootFilesystem: true)
+  # Add directories that need to be writable
+  writableDirs:
+    - /tmp # Required for remediation.log
+  # Security context configuration
+  # WARNING: These settings may impact functionality. Test thoroughly before enabling.
+  securityContext:
+    # Pod-level security context
+    pod:
+      # runAsNonRoot: true
+      # runAsUser: 1000
+      # runAsGroup: 1000
+      # fsGroup: 1000
+      # seccompProfile:
+      #   type: RuntimeDefault
+    # Container-level security context
+    container:
+      # allowPrivilegeEscalation: false
+      # readOnlyRootFilesystem: false
+      # runAsNonRoot: true
+      # runAsUser: 1000
+      # capabilities:
+      #   drop:
+      #     - ALL
+      #   add: []  # Add only required capabilities if needed
 
 bleedsecrets:
   enabled: true
@@ -138,3 +211,27 @@ bleedsecrets:
   tolerations: {}
   hostAliases:
   extraEnv: {}
+  # Writable directories (required when readOnlyRootFilesystem: true)
+  # Add directories that need to be writable, e.g., ["/tmp", "/var/tmp"]
+  writableDirs: []
+  # Security context configuration
+  # WARNING: These settings may impact functionality. Test thoroughly before enabling.
+  securityContext:
+    # Pod-level security context
+    pod:
+      # runAsNonRoot: true
+      # runAsUser: 1000
+      # runAsGroup: 1000
+      # fsGroup: 1000
+      # seccompProfile:
+      #   type: RuntimeDefault
+    # Container-level security context
+    container:
+      # allowPrivilegeEscalation: false
+      # readOnlyRootFilesystem: false
+      # runAsNonRoot: true
+      # runAsUser: 1000
+      # capabilities:
+      #   drop:
+      #     - ALL
+      #   add: []  # Add only required capabilities if needed


### PR DESCRIPTION
Add support for security context in codesec agent.

verified for:

📋 Deployment Spec:
  Pod-level runAsNonRoot:
    ✅ true
  Pod-level runAsUser:
    ✅ 1000 (matches expected)
  Container-level runAsNonRoot:
    ✅ true
  Container-level runAsUser:
    ✅ 1000 (matches expected)
  Capabilities drop:
    ✅ ALL (all capabilities dropped)
  Allow privilege escalation:
    ✅ false (privilege escalation disabled)
  Read-only root filesystem:
    ✅ true (read-only filesystem enabled)
  Seccomp profile:
    ✅ RuntimeDefault (seccomp profile enabled)

🔍 Pod Runtime Status:
  Running as UID:
    ✅ 1000 (matches expected)
  Running as user:
    ℹ️  node
  Runtime capabilities:
    ✅ None (all dropped)
  Privilege escalation (NoNewPrivs):
    ✅ Disabled (NoNewPrivs: 1)
  Root filesystem write test:
    ✅ Read-only (write test failed as expected)