### PR TITLE
add toleration to Trivy-operator deployment

### DIFF
--- a/kube-enforcer/templates/trivy-deployment.yaml
+++ b/kube-enforcer/templates/trivy-deployment.yaml
@@ -140,4 +140,8 @@ spec:
       nodeSelector:
         {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.trivy.tolerations }}
+      tolerations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -417,6 +417,7 @@ trivy:
     failureThreshold: 10
   resources: {}
   nodeSelector: {}
+  tolerations: []
   securityContext: {}
 
 


### PR DESCRIPTION
The absence of tolerations logic in the Trivy operator deployment causes the operator pod to remain in a Pending state in environments where node selectors and taints are configured.