### PR TITLE
fix(kube-enforcer): honour trivy.serviceAccount.create value

### DIFF
--- a/kube-enforcer/templates/trivy-service-account.yaml
+++ b/kube-enforcer/templates/trivy-service-account.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if .Values.trivy.enabled }}
+{{- if and .Values.trivy.enabled .Values.trivy.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
The trivy-service-account.yaml template ignored .Values.trivy.serviceAccount.create, causing the ServiceAccount to always be created when trivy was enabled. This leads to Helm drift when the ServiceAccount is managed externally (e.g. by the Enforcer chart).

Fixes: SLK-111352
Relates-to: ELV-6289