### PR TITLE
Support Ingress spec IngressClassName on server/web-ingress.yaml

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 2022.4.35 (Mar 4th, 2026)
+* Support Ingress spec IngressClassName on server/web-ingress.yaml - [#719](https://github.com/aquasecurity/aqua-helm/issues/719)
+
 ## 2022.4.34 (Aug 25th, 2025)
 * SLK-99523 Adding DB Upgrade Job image pull policy attachement enforcement - [#987](https://github.com/aquasecurity/aqua-helm/issues/987)
 

--- a/server/Chart.yaml
+++ b/server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2022.4"
 description: A Helm chart for the Aqua Console components
 name: server
-version: "2022.4.34"
+version: "2022.4.35"
 dependencies:
   - name: gateway
     version: "2022.4.17"

--- a/server/templates/web-ingress.yaml
+++ b/server/templates/web-ingress.yaml
@@ -28,6 +28,9 @@ metadata:
 {{ toYaml .Values.web.ingress.annotations | indent 4 }}
 {{- end }}
 spec:
+{{ if .Values.web.ingress.ingressClass }}
+  ingressClassName: {{ .Values.web.ingress.ingressClass }}
+{{ end }}
   {{ if .Values.web.ingress.hosts }}
   rules:
     {{- range $host := (required "A valid .Values.web.ingress.hosts entry required!" .Values.web.ingress.hosts) }}

--- a/server/values.yaml
+++ b/server/values.yaml
@@ -397,6 +397,7 @@ web:
     externalPort:
     annotations: {}
     #  kubernetes.io/ingress.class: nginx
+    ingressClass:
     hosts: #REQUIRED
     # - aquasec-test.example.com
     path: /


### PR DESCRIPTION
Resolves https://github.com/aquasecurity/aqua-helm/issues/719

Currently, The aqua-server values .web.ingress does not support ingressClassName.

https://github.com/aquasecurity/aqua-helm/blob/2022.4/server/values.yaml#L348-L364
https://github.com/aquasecurity/aqua-helm/blob/2022.4/server/templates/web-ingress.yaml#L31-L67

Set ingressClass via Annotation was deprecated and nginx-ingress-controller does not support annotation nowadays.
https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation