### PR TITLE
SLK-93353: Remove CAP_SYS_MODULE from enforcer and kube-enforcer

### DIFF
--- a/aqua-quickstart/templates/rbac.yaml
+++ b/aqua-quickstart/templates/rbac.yaml
@@ -108,7 +108,6 @@ allowedCapabilities:
 - MKNOD
 - SETGID
 - SETUID
-- SYS_MODULE
 - AUDIT_CONTROL
 - SYSLOG
 - SYS_CHROOT

--- a/enforcer/templates/rbac.yaml
+++ b/enforcer/templates/rbac.yaml
@@ -115,7 +115,6 @@ allowedCapabilities:
 - MKNOD
 - SETGID
 - SETUID
-- SYS_MODULE
 - AUDIT_CONTROL
 - SYSLOG
 - SYS_CHROOT

--- a/enforcer/values.yaml
+++ b/enforcer/values.yaml
@@ -102,7 +102,6 @@ securityContext:
       - MKNOD
       - SETGID
       - SETUID
-      - SYS_MODULE
       - AUDIT_CONTROL
       - SYSLOG
       - SYS_CHROOT

--- a/kube-enforcer/values.yaml
+++ b/kube-enforcer/values.yaml
@@ -519,7 +519,6 @@ enforcer:
         - MKNOD
         - SETGID
         - SETUID
-        - SYS_MODULE
         - AUDIT_CONTROL
         - SYSLOG
         - SYS_CHROOT


### PR DESCRIPTION
## Summary

Remove `CAP_SYS_MODULE` from enforcer and kube-enforcer Helm charts. The enforcer does not load kernel modules. Talos Linux blocks this capability, preventing the enforcer container from starting.

Files changed:
- `enforcer/values.yaml`
- `enforcer/templates/rbac.yaml`
- `aqua-quickstart/templates/rbac.yaml`
- `kube-enforcer/values.yaml`

## Related

- Companion change in deployments: https://github.com/aquasecurity/deployments/pull/631