### PR TITLE
if version field is used to hold Image repo digest, truncate up to al…

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This repository includes the following charts; they can be deployed separately:
 | [Server](server/)                   | Deploys the Console, Database, and Gateway components; optionally deploys Envoy component                                                                     | 2022.4.35            |
 | [Enforcer](enforcer/)               | Deploys the Aqua Enforcer daemonset                                                                                                                           | 2022.4.29            |
 | [Scanner](scanner/)                 | Deploys the Aqua Scanner deployment                                                                                                                           | 2022.4.13            |
-| [KubeEnforcer](kube-enforcer/)      | Deploys Aqua KubeEnforcer                                                                                                                                     | 2022.4.74            |
+| [KubeEnforcer](kube-enforcer/)      | Deploys Aqua KubeEnforcer                                                                                                                                     | 2022.4.76            |
 | [Gateway](gateway)                  | Deploys the Aqua Standalone Gateway                                                                                                                           | 2022.4.17            |
 | [Tenant-Manager](tenant-manager/)   | Deploys the Aqua Tenant Manager                                                                                                                               | 2022.4.1             |
 | [Cyber Center](cyber-center/)       | Deploys Aqua CyberCenter offline for air-gap environment                                                                                                      | 2022.4.6             |
@@ -82,7 +82,7 @@ aqua-helm/codesec-agent         1.2.11          2022.4          A Helm chart for
 aqua-helm/cloud-connector       2022.4.4        2022.4          A Helm chart for Aqua Cloud-Connector
 aqua-helm/cyber-center          2022.4.6        2022.4          A Helm chart for Aqua CyberCenter
 aqua-helm/enforcer              2022.4.29       2022.4          A Helm chart for the Aqua Enforcer
-aqua-helm/kube-enforcer         2022.4.74       2022.4          A Helm chart for the Aqua KubeEnforcer Starboard/Trivy
+aqua-helm/kube-enforcer         2022.4.76       2022.4          A Helm chart for the Aqua KubeEnforcer Starboard/Trivy
 aqua-helm/gateway               2022.4.17       2022.4          A Helm chart for the Aqua Gateway
 aqua-helm/scanner               2022.4.13       2022.4          A Helm chart for the Aqua Scanner CLI component
 aqua-helm/server                2022.4.35       2022.4          A Helm chart for the Aqua Console components

--- a/kube-enforcer/Chart.yaml
+++ b/kube-enforcer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2022.4"
 description: A Helm chart for the Aqua KubeEnforcer
 name: kube-enforcer
-version: "2022.4.75"
+version: "2022.4.76"
 dependencies:
   - name: enforcer
     version: "2022.4.29"

--- a/kube-enforcer/templates/starboard-conftest-config.yaml
+++ b/kube-enforcer/templates/starboard-conftest-config.yaml
@@ -28,5 +28,5 @@ metadata:
     heritage: "{{ .Release.Service }}"
     app.kubernetes.io/name: {{ .Values.starboard.appName }}
     app.kubernetes.io/instance: {{ .Values.starboard.appName }}
-    app.kubernetes.io/version: {{ .Values.starboard.image.tag | quote }}
+    app.kubernetes.io/version: {{ .Values.starboard.image.tag | trunc 63 | quote }}
 {{- end }}

--- a/kube-enforcer/templates/trivy-configmap.yaml
+++ b/kube-enforcer/templates/trivy-configmap.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ .Values.trivy.appName }}
     app.kubernetes.io/instance: {{ .Values.trivy.appName }}
-    app.kubernetes.io/version: {{ .Values.trivy.image.tag | quote }}
+    app.kubernetes.io/version: {{ .Values.trivy.image.tag | trunc 63 | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 data:
   scanJob.podTemplateContainerSecurityContext: "{\"allowPrivilegeEscalation\":false,\"capabilities\":{\"drop\":[\"ALL\"]},\"privileged\":false,\"readOnlyRootFilesystem\":true}"
@@ -25,7 +25,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ .Values.trivy.appName }}
     app.kubernetes.io/instance: {{ .Values.trivy.appName }}
-    app.kubernetes.io/version: {{ .Values.trivy.image.tag | quote }}
+    app.kubernetes.io/version: {{ .Values.trivy.image.tag | trunc 63 | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 data:
   trivy.repository: "ghcr.io/aquasecurity/trivy"
@@ -53,6 +53,6 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ .Values.trivy.appName }}
     app.kubernetes.io/instance: {{ .Values.trivy.appName }}
-    app.kubernetes.io/version: {{ .Values.trivy.image.tag | quote }}
+    app.kubernetes.io/version: {{ .Values.trivy.image.tag | trunc 63 | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 {{- end }}


### PR DESCRIPTION
app.kubernetes.io/version can be used to hold Image Repo digest ( it's length is 64 chars ), so truncate provided value up to kubernetes label allowed length - 63 chars