### PR TITLE
fix(kube-enforcer): add helm.sh label to Trivy

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This repository includes the following charts; they can be deployed separately:
 | [Server](server/)                   | Deploys the Console, Database, and Gateway components; optionally deploys Envoy component                                                                     | 2022.4.35            |
 | [Enforcer](enforcer/)               | Deploys the Aqua Enforcer daemonset                                                                                                                           | 2022.4.30            |
 | [Scanner](scanner/)                 | Deploys the Aqua Scanner deployment                                                                                                                           | 2022.4.13            |
-| [KubeEnforcer](kube-enforcer/)      | Deploys Aqua KubeEnforcer                                                                                                                                     | 2022.4.77            |
+| [KubeEnforcer](kube-enforcer/)      | Deploys Aqua KubeEnforcer                                                                                                                                     | 2022.4.78            |
 | [Gateway](gateway)                  | Deploys the Aqua Standalone Gateway                                                                                                                           | 2022.4.18            |
 | [Tenant-Manager](tenant-manager/)   | Deploys the Aqua Tenant Manager                                                                                                                               | 2022.4.1             |
 | [Cyber Center](cyber-center/)       | Deploys Aqua CyberCenter offline for air-gap environment                                                                                                      | 2022.4.6             |
@@ -82,7 +82,7 @@ aqua-helm/codesec-agent         1.2.11          2022.4          A Helm chart for
 aqua-helm/cloud-connector       2022.4.4        2022.4          A Helm chart for Aqua Cloud-Connector
 aqua-helm/cyber-center          2022.4.6        2022.4          A Helm chart for Aqua CyberCenter
 aqua-helm/enforcer              2022.4.30       2022.4          A Helm chart for the Aqua Enforcer
-aqua-helm/kube-enforcer         2022.4.77       2022.4          A Helm chart for the Aqua KubeEnforcer Starboard/Trivy
+aqua-helm/kube-enforcer         2022.4.78       2022.4          A Helm chart for the Aqua KubeEnforcer Starboard/Trivy
 aqua-helm/gateway               2022.4.18       2022.4          A Helm chart for the Aqua Gateway
 aqua-helm/scanner               2022.4.13       2022.4          A Helm chart for the Aqua Scanner CLI component
 aqua-helm/server                2022.4.35       2022.4          A Helm chart for the Aqua Console components

--- a/kube-enforcer/CHANGELOG.md
+++ b/kube-enforcer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
+
+## 2022.4.78 ( May 4th, 2026)
+* Add helm.sh/chart label to Trivy resources
+
 ## 2022.4.77 ( May 4th, 2026 )
 * update enforcer chart to 2022.4.30
 

--- a/kube-enforcer/Chart.yaml
+++ b/kube-enforcer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2022.4"
 description: A Helm chart for the Aqua KubeEnforcer
 name: kube-enforcer
-version: "2022.4.77"
+version: "2022.4.78"
 dependencies:
   - name: enforcer
     version: "2022.4.30"

--- a/kube-enforcer/templates/trivy-clusterrolebinding.yaml
+++ b/kube-enforcer/templates/trivy-clusterrolebinding.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Values.trivy.appName }}
     app.kubernetes.io/version: {{ .Values.trivy.image.tag | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    helm.sh/chart: {{ include "aqua.chart" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/kube-enforcer/templates/trivy-configmap.yaml
+++ b/kube-enforcer/templates/trivy-configmap.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Values.trivy.appName }}
     app.kubernetes.io/version: {{ .Values.trivy.image.tag | trunc 63 | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    helm.sh/chart: {{ include "aqua.chart" . }}
 data:
   scanJob.podTemplateContainerSecurityContext: "{\"allowPrivilegeEscalation\":false,\"capabilities\":{\"drop\":[\"ALL\"]},\"privileged\":false,\"readOnlyRootFilesystem\":true}"
   scanJob.compressLogs: "true"
@@ -27,6 +28,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Values.trivy.appName }}
     app.kubernetes.io/version: {{ .Values.trivy.image.tag | trunc 63 | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    helm.sh/chart: {{ include "aqua.chart" . }}
 data:
   trivy.repository: "ghcr.io/aquasecurity/trivy"
   trivy.tag: "0.69.1"
@@ -55,4 +57,5 @@ metadata:
     app.kubernetes.io/instance: {{ .Values.trivy.appName }}
     app.kubernetes.io/version: {{ .Values.trivy.image.tag | trunc 63 | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    helm.sh/chart: {{ include "aqua.chart" . }}
 {{- end }}

--- a/kube-enforcer/templates/trivy-deployment.yaml
+++ b/kube-enforcer/templates/trivy-deployment.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Values.trivy.appName }}
     app.kubernetes.io/version: {{ .Values.trivy.image.tag | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    helm.sh/chart: {{ include "aqua.chart" . }}
 spec:
   replicas: {{ .Values.trivy.replicaCount }}
   strategy:
@@ -25,6 +26,7 @@ spec:
         app.kubernetes.io/instance: {{ .Values.trivy.appName }}
         app.kubernetes.io/version: {{ .Values.trivy.image.tag | quote }}
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        helm.sh/chart: {{ include "aqua.chart" . }}
     spec:
       serviceAccountName: {{ template "serviceAccountTrivy" . }}
       automountServiceAccountToken: true

--- a/kube-enforcer/templates/trivy-role.yaml
+++ b/kube-enforcer/templates/trivy-role.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Values.trivy.appName }}
     app.kubernetes.io/version: {{ .Values.trivy.image.tag | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    helm.sh/chart: {{ include "aqua.chart" . }}
 rules:
   - apiGroups:
       - ""

--- a/kube-enforcer/templates/trivy-rolebinding.yaml
+++ b/kube-enforcer/templates/trivy-rolebinding.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Values.trivy.appName }}
     app.kubernetes.io/version: {{ .Values.trivy.image.tag | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    helm.sh/chart: {{ include "aqua.chart" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/kube-enforcer/templates/trivy-secret.yaml
+++ b/kube-enforcer/templates/trivy-secret.yaml
@@ -10,4 +10,5 @@ metadata:
     app.kubernetes.io/instance: {{ .Values.trivy.appName }}
     app.kubernetes.io/version: {{ .Values.trivy.image.tag | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    helm.sh/chart: {{ include "aqua.chart" . }}
 {{- end }}

--- a/kube-enforcer/templates/trivy-service-account.yaml
+++ b/kube-enforcer/templates/trivy-service-account.yaml
@@ -10,4 +10,5 @@ metadata:
     app.kubernetes.io/instance: {{ .Values.trivy.appName }}
     app.kubernetes.io/version: {{ .Values.trivy.image.tag | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    helm.sh/chart: {{ include "aqua.chart" . }}
 {{- end }}


### PR DESCRIPTION
Added `helm.sh/chart` label only to resources where `app.kubernetes.io` labels where already present.