### PR TITLE
Don't include namespace in cluster resources

### DIFF
--- a/aqua-quickstart/templates/mutating-webhook.yaml
+++ b/aqua-quickstart/templates/mutating-webhook.yaml
@@ -2,7 +2,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ .Values.ke.webhooks.mutatingWebhook.name }}
-  namespace: {{ .Release.Namespace }}
 webhooks:
   - name: microenforcer.aquasec.com
     sideEffects: "None"

--- a/aqua-quickstart/templates/validating-webhook.yaml
+++ b/aqua-quickstart/templates/validating-webhook.yaml
@@ -2,7 +2,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ .Values.ke.webhooks.validatingWebhook.name }}
-  namespace: {{ .Release.Namespace }}
 webhooks:
   - name: imageassurance.aquasec.com
     failurePolicy: {{ .Values.ke.webhooks.failurePolicy }}

--- a/kube-enforcer/templates/auto-generate-tls.yaml
+++ b/kube-enforcer/templates/auto-generate-tls.yaml
@@ -41,7 +41,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ .Values.webhooks.validatingWebhook.name }}
-  namespace: {{ .Release.Namespace }}
   labels:
     role: {{ .Release.Name }}
     app: {{ include "kube-enforcer.fullname" . }}
@@ -105,7 +104,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ .Values.webhooks.mutatingWebhook.name }}
-  namespace: {{ .Release.Namespace }}
   labels:
     role: {{ .Release.Name }}
     app: {{ include "kube-enforcer.fullname" . }}

--- a/kube-enforcer/templates/mutating-webhook.yaml
+++ b/kube-enforcer/templates/mutating-webhook.yaml
@@ -4,7 +4,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ .Values.webhooks.mutatingWebhook.name }}
-  namespace: {{ .Release.Namespace }}
   labels:
     role: {{ .Release.Name }}
     app: {{ include "kube-enforcer.fullname" . }}

--- a/kube-enforcer/templates/validating-webhook.yaml
+++ b/kube-enforcer/templates/validating-webhook.yaml
@@ -4,7 +4,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ .Values.webhooks.validatingWebhook.name }}
-  namespace: {{ .Release.Namespace }}
   labels:
     role: {{ .Release.Name }}
     app: {{ include "kube-enforcer.fullname" . }}


### PR DESCRIPTION
== DETAILS

MutatingWebhookConfiguration and ValidatingWebhookConfiguration are not namespaced resources, which causes these manifests to fail validation. We are working around the issue by using a patch to remove the namespace from the rendered template, but it'd be nice to not have to do that