### PR TITLE
Fix Enforcer environment variables documentation link

### DIFF
--- a/enforcer/values.yaml
+++ b/enforcer/values.yaml
@@ -205,7 +205,7 @@ TLS:
   tls_verify: false
 
 # extraEnvironmentVars is a list of extra environment variables to set in the enforcer daemonSet.
-# https://docs.aquasec.com/v2022.4/platform/deployments/environment-variables/enforcer-optional-variables/
+# https://docs.aquasec.com/v2022.4/platform/deployments/environment-variables/aqua-enforcer-env-variables/
 # The variables could be provided via values.yaml file as shown below
 # or using cli command, for example:  --set extraEnvironmentVars.http_proxy="1.1.1.1",extraEnvironmentVars.https_proxy="2.2.2.2"
 extraEnvironmentVars: {}

--- a/enforcer/values.yaml
+++ b/enforcer/values.yaml
@@ -345,7 +345,7 @@ windowsEnforcer:
     tls_verify: false
 
   # extraEnvironmentVars is a list of extra environment variables to set in the enforcer daemonSet.
-  # https://docs.aquasec.com/v2022.4/platform/deployments/environment-variables/enforcer-optional-variables/
+  # https://docs.aquasec.com/v2022.4/platform/deployments/environment-variables/aqua-enforcer-env-variables/
   # The variables could be provided via values.yaml file as shown below
   # or using cli command, for example:  --set extraEnvironmentVars.http_proxy="1.1.1.1",extraEnvironmentVars.https_proxy="2.2.2.2"
   extraEnvironmentVars: {}


### PR DESCRIPTION
Updates the Enforcer extraEnvironmentVars documentation link to point to the correct Aqua Enforcer environment variables page.